### PR TITLE
allow simple, text-only usage

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,6 +5,16 @@ var cliSpinners = require('cli-spinners');
 var objectAssign = require('object-assign');
 
 function Ora(options) {
+	if (!(this instanceof Ora)) {
+		return new Ora(options);
+	}
+
+	if (typeof options === 'string') {
+		options = {
+			text: options
+		};
+	}
+
 	this.options = objectAssign({
 		text: '',
 		color: 'cyan',

--- a/readme.md
+++ b/readme.md
@@ -15,9 +15,9 @@ $ npm install --save ora
 ## Usage
 
 ```js
-const Ora = require('ora');
+const ora = require('ora');
 
-const spinner = new Ora({text: 'Loading unicorns'});
+const spinner = ora('Loading unicorns');
 
 spinner.start();
 
@@ -32,9 +32,13 @@ setTimeout(() => {
 
 It will gracefully not do anything when there's no TTY or when in a CI.
 
-### Ora([options])
+### ora([options])
 
 #### options
+
+Type: `string` `object`
+
+If a string is provided, it is treated as a shortcut for [`options.text`](#text). The rest of the options listed below will use their default values.
 
 ##### text
 

--- a/test.js
+++ b/test.js
@@ -2,17 +2,7 @@ import test from 'ava';
 import hookStd from 'hook-std';
 import Ora from './';
 
-test(t => {
-	// TODO: use the the `stream` option instead of hooking stderr
-
-	process.stderr.isTTY = true;
-	process.stderr.clearLine = function () {};
-	process.stderr.cursorTo = function () {};
-
-	const spinner = new Ora({text: 'foo', color: false});
-
-	spinner.enabled = true;
-
+function readOutput(spinner, callback) {
 	let out = '';
 
 	const unhook = hookStd.stderr({silent: true}, output => {
@@ -20,9 +10,42 @@ test(t => {
 	});
 
 	spinner.start();
-
-	t.is(out, '⠋ foo');
-
 	spinner.stop();
 	unhook();
+
+	callback(out);
+}
+
+test.before(() => {
+	// TODO: use the the `stream` option instead of hooking stderr
+
+	process.stderr.isTTY = true;
+	process.stderr.clearLine = function () {};
+	process.stderr.cursorTo = function () {};
+});
+
+test(t => {
+	t.plan(1);
+
+	const spinner = new Ora({text: 'foo', color: false});
+
+	spinner.enabled = true;
+
+	readOutput(spinner, (output) => {
+		t.is(output, '⠋ foo');
+	});
+});
+
+test(t => {
+	t.plan(1);
+
+	const ora = Ora;
+	const spinner = ora('foo');
+
+	spinner.color = false;
+	spinner.enabled = true;
+
+	readOutput(spinner, (output) => {
+		t.is(output, '⠋ foo');
+	});
 });


### PR DESCRIPTION
I'm not sure this is wanted at all, but I thought a easiest-path, non-`new` option of getting a spinner object might be welcome. Let me know if it's gross!

Example usage after this PR:

```js
var ora = require('ora');
var spinner = ora('Loading...');
spinner.start();
```