### PR TITLE
prevent start if already started - fixes #5

### DIFF
--- a/index.js
+++ b/index.js
@@ -65,7 +65,7 @@ Ora.prototype.render = function () {
 };
 
 Ora.prototype.start = function () {
-	if (!this.enabled) {
+	if (!this.enabled || this.id) {
 		return;
 	}
 

--- a/test.js
+++ b/test.js
@@ -24,6 +24,19 @@ test.before(() => {
 	process.stderr.cursorTo = function () {};
 });
 
+test('id is not set when created', t => {
+	const spinner = new Ora({text: 'foo', color: false});
+	t.notOk(spinner.id);
+});
+
+test('ignore consecutive calls to `start`', t => {
+	const spinner = new Ora({text: 'foo', color: false});
+	spinner.start();
+	const id = spinner.id;
+	spinner.start();
+	t.same(id, spinner.id);
+});
+
 test(t => {
 	t.plan(1);
 


### PR DESCRIPTION
This small change fixes #5. At least, I think it does :). As long as the interval is running (and thus the spinner is spinning), multiple calls to `start` won't do a thing.