### PR TITLE
Make the API chainable

### DIFF
--- a/index.js
+++ b/index.js
@@ -72,6 +72,8 @@ Ora.prototype.start = function () {
 	cliCursor.hide();
 	this.render();
 	this.id = setInterval(this.render.bind(this), this.interval);
+
+	return this;
 };
 
 Ora.prototype.stop = function () {

--- a/index.js
+++ b/index.js
@@ -34,7 +34,7 @@ function Ora(options) {
 	this.stream = this.options.stream;
 	this.id = null;
 	this.frameIndex = 0;
-	this.enabled = (this.stream && this.stream.isTTY) && !process.env.CI;
+	this.enabled = this.options.enabled || ((this.stream && this.stream.isTTY) && !process.env.CI);
 }
 
 Ora.prototype.frame = function () {
@@ -57,11 +57,15 @@ Ora.prototype.clear = function () {
 
 	this.stream.clearLine();
 	this.stream.cursorTo(0);
+
+	return this;
 };
 
 Ora.prototype.render = function () {
 	this.clear();
 	this.stream.write(this.frame());
+
+	return this;
 };
 
 Ora.prototype.start = function () {
@@ -86,6 +90,8 @@ Ora.prototype.stop = function () {
 	this.frameIndex = 0;
 	this.clear();
 	cliCursor.show();
+
+	return this;
 };
 
 module.exports = Ora;

--- a/readme.md
+++ b/readme.md
@@ -17,9 +17,7 @@ $ npm install --save ora
 ```js
 const ora = require('ora');
 
-const spinner = ora('Loading unicorns');
-
-spinner.start();
+const spinner = ora('Loading unicorns').start();
 
 setTimeout(() => {
 	spinner.color = 'yellow';
@@ -88,27 +86,34 @@ Stream to write the output.
 
 You could for example set this to `process.stdout` instead.
 
+##### enabled
+
+Type: `boolean`<br>
+Default: `false`
+
+Force enabling of the spinner regardless of the `stream` not being run inside a TTY context and/or in a CI environment.
+
 ### Instance
 
 #### .start()
 
-Start the spinner.
+Start the spinner. Returns the instance.
 
 #### .stop()
 
-Stop and clear the spinner.
+Stop and clear the spinner. Returns the instance.
 
 #### .clear()
 
-Clear the spinner.
+Clear the spinner. Returns the instance.
+
+#### .render()
+
+Manually render a new frame. Returns the instance.
 
 #### .frame()
 
 Get a new frame.
-
-#### .render()
-
-Manually render a new frame.
 
 #### .text
 

--- a/test.js
+++ b/test.js
@@ -29,9 +29,11 @@ test.before(() => {
 test('main', t => {
 	t.plan(1);
 
-	const spinner = new Ora({text: 'foo', color: false});
-
-	spinner.enabled = true;
+	const spinner = new Ora({
+		text: 'foo',
+		color: false,
+		enabled: true
+	});
 
 	readOutput(spinner, (output) => {
 		t.is(output, `${spinnerChar} foo`);
@@ -66,6 +68,11 @@ test('ignore consecutive calls to `.start()`', t => {
 });
 
 test('chain call to `.start()` with constructor', t => {
-	const spinner = new Ora('foo').start();
+	const spinner = new Ora({
+		text: 'foo',
+		enabled: true
+	}).start();
+
 	t.truthy(spinner.id);
+	t.true(spinner.enabled);
 });

--- a/test.js
+++ b/test.js
@@ -64,3 +64,8 @@ test('ignore consecutive calls to `.start()`', t => {
 	spinner.start();
 	t.is(id, spinner.id);
 });
+
+test('chain call to `.start()` with constructor', t => {
+	const spinner = new Ora('foo').start();
+	t.truthy(spinner.id);
+});


### PR DESCRIPTION
Does it make sense to `return` it anywhere else? Maybe in `.render()` and `.clear()` in case you want to do something like this (for some reason):

```js
const ora = require('ora')
const spinner = ora('Loading unicorns')
    .render()
    .render()
    .render()
    .clear()
    .start();
```

Fixes #10.