### PR TITLE
Use the stream option instead of hooking stderr - fixes #1 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,5 +2,3 @@ language: node_js
 node_js:
   - '6'
   - '4'
-  - '0.12'
-  - '0.10'

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "url": "sindresorhus.com"
   },
   "engines": {
-    "node": ">=0.10.0"
+    "node": ">=4.0.0"
   },
   "scripts": {
     "test": "xo && ava"

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   },
   "devDependencies": {
     "ava": "*",
-    "hook-std": "^0.2.0",
+    "get-stream": "^2.3.0",
     "xo": "*"
   }
 }


### PR DESCRIPTION
- use the the `stream` option instead of hooking stderr
- remove hook-std, it's not needed anymore

I'm using this approach on [my project that uses Ora](https://github.com/josmardias/bike-vitoria/blob/master/src/loading-spinner-test.js)