### PR TITLE
Add `.promise()` method

### DIFF
--- a/index.js
+++ b/index.js
@@ -99,23 +99,23 @@ class Ora {
 	}
 }
 
-function promise(action, options) {
-	if (typeof action.then === 'function') {
-		const spinner = new Ora(options);
-		spinner.start();
-		action.then(() => {
-			spinner.succeed();
-		},
-		() => {
-			spinner.fail();
-		});
-	} else {
-		throw new Error('Parameter `action` must be a Promise');
-	}
-}
-
 module.exports = function (opts) {
 	return new Ora(opts);
 };
 
-module.exports.promise = promise;
+module.exports.promise = function (action, options) {
+	if (typeof action.then !== 'function') {
+		throw new Error('Parameter `action` must be a Promise');
+	}
+
+	const spinner = new Ora(options);
+	spinner.start();
+	action.then(() => {
+		spinner.succeed();
+	},
+	() => {
+		spinner.fail();
+	});
+
+	return spinner;
+};

--- a/index.js
+++ b/index.js
@@ -99,6 +99,23 @@ class Ora {
 	}
 }
 
+function promise(action, options) {
+	if (typeof action.then === 'function') {
+		const spinner = new Ora(options);
+		spinner.start();
+		action.then(() => {
+			spinner.succeed();
+		},
+		() => {
+			spinner.fail();
+		});
+	} else {
+		throw new Error('Parameter `action` must be a Promise');
+	}
+}
+
 module.exports = function (opts) {
 	return new Ora(opts);
 };
+
+module.exports.promise = promise;

--- a/readme.md
+++ b/readme.md
@@ -137,6 +137,16 @@ Change the text.
 
 Change the spinner color.
 
+### ora.promise(action, [options|text])
+
+Starts a spinner for a promise. The spinner is stopped with `succeed` if the promise resolves successfully and with `fail` of it gets rejected.
+
+##### action
+Type: `promise`<br>
+
+##### [options|text]
+
+Same as the options passed to the ora() function.
 
 ## Related
 

--- a/readme.md
+++ b/readme.md
@@ -139,14 +139,15 @@ Change the spinner color.
 
 ### ora.promise(action, [options|text])
 
-Starts a spinner for a promise. The spinner is stopped with `succeed` if the promise resolves successfully and with `fail` of it gets rejected.
+Starts a spinner for a promise. The spinner is stopped with `succeed` if the promise resolves successfully and with `fail` of it gets rejected. Returns the spinner instance created internally.
 
 ##### action
-Type: `promise`<br>
+
+Type: `Promise`
 
 ##### [options|text]
 
-Same as the options passed to the ora() function.
+Same as the options passed to the `ora()` function.
 
 ## Related
 

--- a/test.js
+++ b/test.js
@@ -155,3 +155,46 @@ test('stopAndPersist with no argument', async t => {
 
 	t.regex(output, /\s foo/);
 });
+
+test('promise resolves', async t => {
+	t.plan(1);
+
+	const stream = getPassThroughStream();
+	const resolves = Promise.resolve(1);
+
+	Ora.promise(resolves, {
+		stream,
+		text: 'foo',
+		color: false,
+		enabled: true
+	});
+
+	await resolves;
+
+	stream.end();
+	const output = await getStream(stream);
+
+	t.regex(output, /✔|√ foo/);
+});
+
+test('promise rejects', async t => {
+	t.plan(1);
+
+	const stream = getPassThroughStream();
+	const rejects = Promise.reject(1);
+
+	Ora.promise(rejects, {
+		stream,
+		text: 'foo',
+		color: false,
+		enabled: true
+	});
+	try {
+		await rejects;
+	} catch (err) {}
+
+	stream.end();
+	const output = await getStream(stream);
+
+	t.regex(output, /✖|× foo/);
+});

--- a/test.js
+++ b/test.js
@@ -161,7 +161,6 @@ test('promise resolves', async t => {
 
 	const stream = getPassThroughStream();
 	const resolves = Promise.resolve(1);
-
 	Ora.promise(resolves, {
 		stream,
 		text: 'foo',
@@ -182,19 +181,18 @@ test('promise rejects', async t => {
 
 	const stream = getPassThroughStream();
 	const rejects = Promise.reject(1);
-
 	Ora.promise(rejects, {
 		stream,
 		text: 'foo',
 		color: false,
 		enabled: true
 	});
+
 	try {
 		await rejects;
 	} catch (err) {}
 
 	stream.end();
 	const output = await getStream(stream);
-
 	t.regex(output, /✖|× foo/);
 });


### PR DESCRIPTION
Closes #19. Just took a jab at it. Not sure about a few things.

Firstly to check if the passed object is a promise I'm using

```
typeof action.then === 'function'
```

I read somewhere that I'm supposed to use 

```
Promise.resolve(action) === action
```

but for some reason it does not work when I run the test.

Also I'm not sure about the thoroughness of my tests or the way im waiting for the promises.

I also know that in general when a promise rejects it's recommended to use a `.catch()` rather than the second parameter to `.then()`, but for some reason this fails in the test case as apparently the stream gets closed before the `.catch()` executes.
