### PR TITLE
add `text` parameter

### DIFF
--- a/index.js
+++ b/index.js
@@ -91,7 +91,7 @@ class Ora {
 	fail(text) {
 		return this.stopAndPersist(logSymbols.erro, text);
 	}
-	stopAndPersist(symbol) {
+	stopAndPersist(symbol, text) {
 		this.stop();
 		text && (this.text = text);
 		this.stream.write(`${symbol || ' '} ${this.text}\n`);

--- a/index.js
+++ b/index.js
@@ -61,7 +61,7 @@ class Ora {
 
 		return this;
 	}
-	start() {
+	start(text) {
 		if (!this.enabled || this.id) {
 			return this;
 		}
@@ -69,7 +69,7 @@ class Ora {
 		cliCursor.hide();
 		this.render();
 		this.id = setInterval(this.render.bind(this), this.interval);
-
+		text && (this.text = text);
 		return this;
 	}
 	stop() {
@@ -85,14 +85,15 @@ class Ora {
 
 		return this;
 	}
-	succeed() {
-		return this.stopAndPersist(logSymbols.success);
+	succeed(text) {
+		return this.stopAndPersist(logSymbols.success, text);
 	}
-	fail() {
-		return this.stopAndPersist(logSymbols.error);
+	fail(text) {
+		return this.stopAndPersist(logSymbols.erro, text);
 	}
 	stopAndPersist(symbol) {
 		this.stop();
+		text && (this.text = text);
 		this.stream.write(`${symbol || ' '} ${this.text}\n`);
 
 		return this;

--- a/index.js
+++ b/index.js
@@ -69,7 +69,9 @@ class Ora {
 		cliCursor.hide();
 		this.render();
 		this.id = setInterval(this.render.bind(this), this.interval);
-		text && (this.text = text);
+		if(text) {
+			this.text = text;
+		}
 		return this;
 	}
 	stop() {
@@ -93,7 +95,9 @@ class Ora {
 	}
 	stopAndPersist(symbol, text) {
 		this.stop();
-		text && (this.text = text);
+		if(text) {
+			this.text = text;
+		}
 		this.stream.write(`${symbol || ' '} ${this.text}\n`);
 
 		return this;

--- a/index.js
+++ b/index.js
@@ -89,7 +89,7 @@ class Ora {
 		return this.stopAndPersist(logSymbols.success, text);
 	}
 	fail(text) {
-		return this.stopAndPersist(logSymbols.erro, text);
+		return this.stopAndPersist(logSymbols.error, text);
 	}
 	stopAndPersist(symbol, text) {
 		this.stop();


### PR DESCRIPTION
- Added `text` parameter to `start()`
- Added `text` parameter to `succeed()`
- Added `text` parameter to `stopAndPersist()`

Set `this.text` from these functions

This is helpful when starting and stopping spinner.  Combines setting the text with each of the functions to make it more concise.  