### PR TITLE
Add text option to start function

### DIFF
--- a/index.js
+++ b/index.js
@@ -61,7 +61,11 @@ class Ora {
 
 		return this;
 	}
-	start() {
+	start(text) {
+		if (text) {
+			this.text = text;
+		}
+
 		if (!this.enabled || this.id) {
 			return this;
 		}

--- a/readme.md
+++ b/readme.md
@@ -94,9 +94,9 @@ Force enable/disable the spinner. If not specified, the spinner will be enabled 
 
 ### Instance
 
-#### .start()
+#### .start([text])
 
-Start the spinner. Returns the instance.
+Start the spinner. Returns the instance. Set the current text if `text` is provided.
 
 #### .stop()
 

--- a/test.js
+++ b/test.js
@@ -121,6 +121,11 @@ test('.stopAndPersist() - with new symbol and text', macro, spinner => {
 	spinner.stopAndPersist({symbol: '@', text: 'all done'});
 }, /@ all done/);
 
+test('.start(text)', macro, spinner => {
+	spinner.start('Test text');
+	spinner.stopAndPersist();
+}, /Test text/);
+
 test('.promise() - resolves', async t => {
 	const stream = getPassThroughStream();
 	const output = getStream(stream);


### PR DESCRIPTION
Added an optional argument to `start` to set the text before starting. I find this very useful with the following pattern:

```js
const spinner = ora()

try {
  spinner.start('Thing a')
  await thingA()
  spinner.succeed()

  spinner.start('Thing b')
  await thingB()
  spinner.succeed()

  // ...
} catch (err) {
  spinner.fail(err.toString())
}
```