### PR TITLE
Add interrupt method

### DIFF
--- a/index.js
+++ b/index.js
@@ -57,7 +57,13 @@ class Ora {
 	}
 	render() {
 		this.clear();
-		this.stream.write(this.frame());
+
+		const frame = this.frame();
+
+		this.stream.write(frame);
+		if (this.lastFrame !== frame) {
+			this.lastFrame = frame;
+		}
 
 		return this;
 	}
@@ -100,6 +106,12 @@ class Ora {
 	}
 	info(text) {
 		return this.stopAndPersist({symbol: logSymbols.info, text});
+	}
+	interrupt(text) {
+		this.stream.clearLine();
+		this.stream.cursorTo(0);
+		this.stream.write(text + '\n');
+		this.stream.write(this.lastFrame);
 	}
 	stopAndPersist(options) {
 		// Legacy argument

--- a/readme.md
+++ b/readme.md
@@ -118,6 +118,10 @@ Stop the spinner, change it to a yellow `⚠` and persist the current text, or `
 
 Stop the spinner, change it to a blue `ℹ` and persist the current text, or `text` if provided. Returns the instance.
 
+#### .interrupt([text])
+
+Prints the `text` provided above the spinner without disturbing its execution.
+
 #### .stopAndPersist([options])
 
 Stop the spinner and change the symbol or text. Returns the instance. See the GIF below.

--- a/test.js
+++ b/test.js
@@ -105,6 +105,10 @@ test('.info()', macro, spinner => {
 	spinner.info();
 }, /(ℹ|i) foo/);
 
+test('.interrupt()', macro, spinner => {
+	spinner.interrupt('breaker');
+}, /breaker\n.\sfoo$/);
+
 test('.stopAndPersist()', macro, spinner => {
 	spinner.stopAndPersist('@');
 }, /@ foo/);


### PR DESCRIPTION
The `interrupt` method allows the user to maintain a the spinner on a single line while writing new messages to the output.

This addresses #49 to a degree. It only allows you to print lines above the spinner, not below. But at least your spinner isn't duplicated on different lines.

![2017-08-14_21-00-17](https://user-images.githubusercontent.com/1084688/29298165-c674890c-8133-11e7-81aa-32588b343079.gif)
