### PR TITLE
Make `stopAnPersist()` not run if spinner is not enabled

### DIFF
--- a/index.js
+++ b/index.js
@@ -102,6 +102,10 @@ class Ora {
 		return this.stopAndPersist({symbol: logSymbols.info, text});
 	}
 	stopAndPersist(options) {
+		if (!this.enabled) {
+			return this;
+		}
+
 		// Legacy argument
 		// TODO: Deprecate sometime in the future
 		if (typeof options === 'string') {

--- a/test.js
+++ b/test.js
@@ -121,6 +121,23 @@ test('.stopAndPersist() - with new symbol and text', macro, spinner => {
 	spinner.stopAndPersist({symbol: '@', text: 'all done'});
 }, /@ all done/);
 
+test('.stopAndPersist() - enabled false - no output', async t => {
+	const stream = getPassThroughStream();
+	const output = getStream(stream);
+
+	const spinner = new Ora({
+		stream,
+		text: 'foo',
+		color: false,
+		enabled: false
+	});
+
+	spinner.start();
+	spinner.stopAndPersist();
+	stream.end();
+	t.is(await output, '');
+});
+
 test('.start(text)', macro, spinner => {
 	spinner.start('Test text');
 	spinner.stopAndPersist();


### PR DESCRIPTION
When running succeed (or fail) the text was outputted even if spinner was not enabled.