### PR TITLE
Clarify `.promise` usage

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -162,11 +162,11 @@ Change the text.
 
 Change the spinner color.
 
-#### .promise(action, [options|text])
+### ora.promise(action, [options|text])
 
 Starts a spinner for a promise. The spinner is stopped with `.succeed()` if the promise fulfills or with `.fail()` if it rejects. Returns the spinner instance.
 
-##### action
+#### action
 
 Type: `Promise`
 


### PR DESCRIPTION
The way it's documented right now, under the `Instance` heading, is quite confusing. It seems to imply I can do this:

```
const spinner = ora('Doing stuff');
spinner.promise(somePromise);
// => Unhandled rejection TypeError: spinner.promise is not a function
```

I had to go read the source code to realize it's not an instance method.

I saw that it was originally documented as `ora.promise` until 85551fb59586d516386214ba098de15af2a1410b. I believe it's better to leave it that way.

Alternatively, you could provide an example.