### PR TITLE
Add halo to the Related section in the readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -176,6 +176,7 @@ Type: `Promise`
 - [cli-spinners](https://github.com/sindresorhus/cli-spinners) - Spinners for use in the terminal
 - [listr](https://github.com/SamVerschueren/listr) - Terminal task list
 - [CLISpinner](https://github.com/kiliankoe/CLISpinner) - Terminal spinner library for Swift
+- [halo](https://github.com/ManrajGrover/halo) - Beautiful terminal spinners in Python
 
 
 ## License

--- a/readme.md
+++ b/readme.md
@@ -176,7 +176,7 @@ Type: `Promise`
 - [cli-spinners](https://github.com/sindresorhus/cli-spinners) - Spinners for use in the terminal
 - [listr](https://github.com/SamVerschueren/listr) - Terminal task list
 - [CLISpinner](https://github.com/kiliankoe/CLISpinner) - Terminal spinner library for Swift
-- [halo](https://github.com/ManrajGrover/halo) - Beautiful terminal spinners in Python
+- [halo](https://github.com/ManrajGrover/halo) - Python port
 
 
 ## License


### PR DESCRIPTION
This PR adds `halo` to `related` section. Thanks for being the inspiration for this package. 😸 