### PR TITLE
Handle wrapping, add hideCursor option

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: node_js
 node_js:
+  - '9'
+  - '8'
   - '6'
   - '4'

--- a/index.js
+++ b/index.js
@@ -79,7 +79,7 @@ class Ora {
 			this.stream.clearLine();
 			this.stream.cursorTo(0);
 		}
-		this.linesToClear = -1;
+		this.linesToClear = 0;
 
 		return this;
 	}

--- a/index.js
+++ b/index.js
@@ -30,6 +30,7 @@ class Ora {
 		}
 
 		this.color = this.options.color;
+		this.hideCursor = this.options.hideCursor !== false;
 		this.interval = this.options.interval || this.spinner.interval || 100;
 		this.stream = this.options.stream;
 		this.id = null;
@@ -100,7 +101,9 @@ class Ora {
 			return this;
 		}
 
-		cliCursor.hide(this.stream);
+		if (this.hideCursor) {
+			cliCursor.hide(this.stream);
+		}
 		this.render();
 		this.id = setInterval(this.render.bind(this), this.interval);
 
@@ -116,7 +119,9 @@ class Ora {
 		this.id = null;
 		this.frameIndex = 0;
 		this.clear();
-		cliCursor.show(this.stream);
+		if (this.hideCursor) {
+			cliCursor.show(this.stream);
+		}
 
 		return this;
 	}

--- a/index.js
+++ b/index.js
@@ -50,7 +50,7 @@ class Ora {
 		this[TEXT] = value;
 		const columns = this.stream.columns || 80;
 		this.lineCount = stripAnsi('--' + value).split('\n').reduce((count, line) => {
-			return count + Math.ceil(wcwidth(line) / columns);
+			return count + Math.max(1, Math.ceil(wcwidth(line) / columns));
 		}, 0);
 	}
 

--- a/index.js
+++ b/index.js
@@ -33,6 +33,7 @@ class Ora {
 		this.frameIndex = 0;
 		this.enabled = typeof this.options.enabled === 'boolean' ? this.options.enabled : ((this.stream && this.stream.isTTY) && !process.env.CI);
 	}
+
 	frame() {
 		const frames = this.spinner.frames;
 		let frame = frames[this.frameIndex];
@@ -45,6 +46,7 @@ class Ora {
 
 		return frame + ' ' + this.text;
 	}
+
 	clear() {
 		if (!this.enabled) {
 			return this;
@@ -55,12 +57,14 @@ class Ora {
 
 		return this;
 	}
+
 	render() {
 		this.clear();
 		this.stream.write(this.frame());
 
 		return this;
 	}
+
 	start(text) {
 		if (text) {
 			this.text = text;
@@ -76,6 +80,7 @@ class Ora {
 
 		return this;
 	}
+
 	stop() {
 		if (!this.enabled) {
 			return this;
@@ -89,18 +94,23 @@ class Ora {
 
 		return this;
 	}
+
 	succeed(text) {
 		return this.stopAndPersist({symbol: logSymbols.success, text});
 	}
+
 	fail(text) {
 		return this.stopAndPersist({symbol: logSymbols.error, text});
 	}
+
 	warn(text) {
 		return this.stopAndPersist({symbol: logSymbols.warning, text});
 	}
+
 	info(text) {
 		return this.stopAndPersist({symbol: logSymbols.info, text});
 	}
+
 	stopAndPersist(options) {
 		if (!this.enabled) {
 			return this;

--- a/package.json
+++ b/package.json
@@ -38,12 +38,13 @@
     "chalk": "^2.1.0",
     "cli-cursor": "^2.1.0",
     "cli-spinners": "^1.0.1",
-    "log-symbols": "^2.1.0"
+    "log-symbols": "^2.1.0",
+    "strip-ansi": "^4.0.0",
+    "wcwidth": "^1.0.1"
   },
   "devDependencies": {
     "ava": "*",
     "get-stream": "^3.0.0",
-    "strip-ansi": "^3.0.1",
     "xo": "*"
   }
 }

--- a/readme.md
+++ b/readme.md
@@ -72,6 +72,10 @@ Values: `black` `red` `green` `yellow` `blue` `magenta` `cyan` `white` `gray`
 
 Color of the spinner.
 
+##### hideCursor
+
+Set to `false` to stop Ora from hiding the cursor.
+
 ##### interval
 
 Type: `number`<br>

--- a/test.js
+++ b/test.js
@@ -11,6 +11,7 @@ const getPassThroughStream = () => {
 	const stream = new PassThroughStream();
 	stream.clearLine = noop;
 	stream.cursorTo = noop;
+	stream.moveCursor = noop;
 	return stream;
 };
 
@@ -180,4 +181,70 @@ test('.promise() - rejects', async t => {
 	stream.end();
 
 	t.regex(stripAnsi(await output), /(✖|×) foo/);
+});
+
+test('erases wrapped lines', t => {
+	const stream = getPassThroughStream();
+	stream.columns = 40;
+	let clearedLines = 0;
+	let cursorAtRow = 0;
+	stream.clearLine = () => {
+		clearedLines++;
+	};
+	stream.moveCursor = (dx, dy) => {
+		cursorAtRow += dy;
+	};
+	const reset = () => {
+		clearedLines = 0;
+		cursorAtRow = 0;
+	};
+
+	const spinner = new Ora({
+		stream,
+		text: 'foo',
+		color: false,
+		enabled: true
+	});
+
+	spinner.render();
+	t.is(clearedLines, 0);
+	t.is(cursorAtRow, 0);
+
+	spinner.text = 'foo\nbar';
+	spinner.render();
+	t.is(clearedLines, 1);
+	t.is(cursorAtRow, 0);
+
+	spinner.render();
+	t.is(clearedLines, 3);
+	t.is(cursorAtRow, -1);
+
+	spinner.clear();
+	reset();
+	spinner.text = '0'.repeat(stream.columns + 10);
+	spinner.render();
+	spinner.render();
+	t.is(clearedLines, 2);
+	t.is(cursorAtRow, -1);
+
+	spinner.clear();
+	reset();
+	// Unicorns take up two cells, so this creates 3 rows of text not two
+	spinner.text = '🦄'.repeat(stream.columns + 10);
+	spinner.render();
+	spinner.render();
+	t.is(clearedLines, 3);
+	t.is(cursorAtRow, -2);
+
+	spinner.clear();
+	reset();
+	// Unicorns take up two cells. Remove the spinner and space and fill two rows,
+	// then force a linebreak and write the third row.
+	spinner.text = '🦄'.repeat(stream.columns - 2) + '\nfoo';
+	spinner.render();
+	spinner.render();
+	t.is(clearedLines, 3);
+	t.is(cursorAtRow, -2);
+
+	spinner.stop();
 });

--- a/test.js
+++ b/test.js
@@ -210,14 +210,14 @@ test('erases wrapped lines', t => {
 	t.is(clearedLines, 0);
 	t.is(cursorAtRow, 0);
 
-	spinner.text = 'foo\nbar';
+	spinner.text = 'foo\n\nbar';
 	spinner.render();
-	t.is(clearedLines, 1);
+	t.is(clearedLines, 1); // Cleared 'foo'
 	t.is(cursorAtRow, 0);
 
 	spinner.render();
-	t.is(clearedLines, 3);
-	t.is(cursorAtRow, -1);
+	t.is(clearedLines, 4); // Cleared 'foo\n\nbar'
+	t.is(cursorAtRow, -2);
 
 	spinner.clear();
 	reset();


### PR DESCRIPTION
Count how many rows are taken up by the spinner and the text and clear the appropriate number of lines. Fix clear() so it doesn't clear *further* lines until render() is called again.

Fixes #38. Fixes #7.

Add hideCursor option. Fixes #27. Users may still hide the cursor outside of Ora.

There aren't any tests for hiding the cursor so I didn't add one for not hiding it either.

---

I did a quick test in the Windows command prompt and the wrap handling seemed to work fine.