### PR TITLE
Add `.isSpinning` property

### DIFF
--- a/index.js
+++ b/index.js
@@ -46,6 +46,10 @@ class Ora {
 		return this[TEXT];
 	}
 
+	get isSpinning() {
+		return this.id !== null;
+	}
+
 	set text(value) {
 		this[TEXT] = value;
 		const columns = this.stream.columns || 80;
@@ -97,7 +101,7 @@ class Ora {
 			this.text = text;
 		}
 
-		if (!this.enabled || this.id) {
+		if (!this.enabled || this.isSpinning) {
 			return this;
 		}
 

--- a/readme.md
+++ b/readme.md
@@ -131,6 +131,10 @@ Stop the spinner, change it to a yellow `⚠` and persist the current text, or `
 
 Stop the spinner, change it to a blue `ℹ` and persist the current text, or `text` if provided. Returns the instance.
 
+#### .isSpinning
+
+Returns a boolean that describes whether the instance is currently spinning.
+
 #### .stopAndPersist([options])
 
 Stop the spinner and change the symbol or text. Returns the instance. See the GIF below.

--- a/readme.md
+++ b/readme.md
@@ -133,7 +133,7 @@ Stop the spinner, change it to a blue `ℹ` and persist the current text, or `te
 
 #### .isSpinning
 
-Returns a boolean that describes whether the instance is currently spinning.
+A boolean of whether the instance is currently spinning.
 
 #### .stopAndPersist([options])
 

--- a/test.js
+++ b/test.js
@@ -51,6 +51,7 @@ test('title shortcut', async t => {
 	spinner.color = false;
 	spinner.enabled = true;
 	spinner.start();
+	t.true(spinner.isSpinning);
 	spinner.stop();
 
 	stream.end();
@@ -61,6 +62,7 @@ test('title shortcut', async t => {
 test('`.id` is not set when created', t => {
 	const spinner = new Ora('foo');
 	t.falsy(spinner.id);
+	t.false(spinner.isSpinning);
 });
 
 test('ignore consecutive calls to `.start()`', t => {


### PR DESCRIPTION
Thought about expanding `isSpinning` to be

```js
return this.enabled && this.id !== null;
```

since it can't be spinning if it's not enabled, but wasn't sure about the implications. That would simplify the check in `start()` to be `if (this.isSpinning)`