### PR TITLE
Don't call stream TTY methods on streams that are not TTYs

### DIFF
--- a/index.js
+++ b/index.js
@@ -72,12 +72,11 @@ class Ora {
 	}
 
 	clear() {
-		if (!this.enabled) {
+		if (!this.enabled || !this.stream.isTTY) {
 			return this;
 		}
 
 		for (let i = 0; i < this.linesToClear; i++) {
-			if ( ! this.stream.isTTY) continue;
 			if (i > 0) {
 				this.stream.moveCursor(0, -1);
 			}

--- a/index.js
+++ b/index.js
@@ -77,6 +77,7 @@ class Ora {
 		}
 
 		for (let i = 0; i < this.linesToClear; i++) {
+			if ( ! this.stream.isTTY) continue;
 			if (i > 0) {
 				this.stream.moveCursor(0, -1);
 			}


### PR DESCRIPTION
moveCursor, clearLine, etc are not methods that every stream will have. Only streams that are specifically TTY streams.

I think by default this.stream is set to process.stderr. In unix it's very possible for stderr to not be a TTY.

When running some node thing in the background (with `concurrently`), I got an exception.