### PR TITLE
Add two spinner packages for Go to the Related section in the readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -199,7 +199,8 @@ Type: `Promise`
 - [spinners](https://github.com/FGRibreau/spinners) - Terminal spinners for Rust
 - [marquee-ora](https://github.com/joeycozza/marquee-ora) - Scrolling marquee spinner for Ora
 - [briandowns/spinner](https://github.com/briandowns/spinner) - Terminal spinner/progress indicator for Go
-- [go-spin](https://github.com/tj/go-spin) - Terminal spinner package for Go
+- [tj/go-spin](https://github.com/tj/go-spin) - Terminal spinner package for Go
+
 
 ## License
 

--- a/readme.md
+++ b/readme.md
@@ -198,7 +198,8 @@ Type: `Promise`
 - [halo](https://github.com/ManrajGrover/halo) - Python port
 - [spinners](https://github.com/FGRibreau/spinners) - Terminal spinners for Rust
 - [marquee-ora](https://github.com/joeycozza/marquee-ora) - Scrolling marquee spinner for Ora
-
+- [briandowns/spinner](https://github.com/briandowns/spinner) - Terminal spinner/progress indicator for Go
+- [go-spin](https://github.com/tj/go-spin) - Terminal spinner package for Go
 
 ## License
 


### PR DESCRIPTION
I was looking for a spinner implementation in Go and found this package.
Happily, you have a `related` section in the README, but there was no Go package.

This PR adds two spinner packages for the Go programing language into the related section in the README.

Thanks for writing this lib :)