### PR TITLE
Fix regression with `stopAndPersist` output

### DIFF
--- a/index.js
+++ b/index.js
@@ -211,7 +211,7 @@ class Ora {
 		const fullText = (typeof text === 'string') ? ' ' + text : '';
 
 		this.stop();
-		this.stream.write(`${fullPrefixText}${options.symbol || ' '}${fullText}n`);
+		this.stream.write(`${fullPrefixText}${options.symbol || ' '}${fullText}\n`);
 
 		return this;
 	}


### PR DESCRIPTION
This appears to be a typo, and was leading to this behavior:

```javascript
const spinner = new ora('Testing').start();
setTimeout(() => spinner.succeed('Completed'), 2000);
```

```
✔ Completedn[~/Development/ora-test (master)]$
```