### PR TITLE
fix: Add Babel compatible `__esModule` export

### DIFF
--- a/index.js
+++ b/index.js
@@ -221,11 +221,13 @@ const oraFactory = function (opts) {
 	return new Ora(opts);
 };
 
-module.exports = oraFactory;
-// TODO: Remove this for the next major release
-module.exports.default = oraFactory;
+exports = module.exports = oraFactory; // eslint-disable-line no-multi-assign
 
-module.exports.promise = (action, options) => {
+// For TypeScript and Babel:
+exports.default = module.exports;
+Object.defineProperty(exports, '__esModule', {value: true});
+
+exports.promise = (action, options) => {
 	if (typeof action.then !== 'function') {
 		throw new TypeError('Parameter `action` must be a Promise');
 	}


### PR DESCRIPTION
Since this module now supports the `default` export, it makes sense to add the Babel compatible `__esModule` export.

## See also:
- https://babeljs.io/docs/en/babel-plugin-transform-modules-commonjs
- https://github.com/chalk/chalk/pull/343