### PR TITLE
Discard stdin by default

### DIFF
--- a/example.js
+++ b/example.js
@@ -7,38 +7,39 @@ const spinner = new Ora({
 	spinner: process.argv[2]
 });
 
+
 const spinnerDiscardingStdin = new Ora({
 	discardStdin: true,
 	text: 'Loading unicorns, discarding stdin',
 	spinner: process.argv[2]
 });
 
-spinner.start();
+spinnerDiscardingStdin.start();
+
+setTimeout(() => {
+	spinnerDiscardingStdin.succeed();
+	spinner.start();
+}, 3000);
 
 setTimeout(() => {
 	spinner.color = 'yellow';
 	spinner.text = `Loading ${chalk.red('rainbows')}`;
-}, 1000);
+}, 4000);
 
 setTimeout(() => {
 	spinner.color = 'green';
 	spinner.indent = 2;
 	spinner.text = 'Loading with indent';
-}, 2000);
+}, 5000);
 
 setTimeout(() => {
 	spinner.indent = 0;
 	spinner.spinner = 'moon';
 	spinner.text = 'Loading with different spinners';
-}, 3000);
+}, 6000);
 
 setTimeout(() => {
 	spinner.succeed();
-	spinnerDiscardingStdin.start();
-}, 4000);
-
-setTimeout(() => {
-	spinnerDiscardingStdin.succeed();
 }, 7000);
 
 // $ node example.js nameOfSpinner

--- a/example.js
+++ b/example.js
@@ -7,7 +7,6 @@ const spinner = new Ora({
 	spinner: process.argv[2]
 });
 
-
 const spinnerDiscardingStdin = new Ora({
 	discardStdin: true,
 	text: 'Loading unicorns, discarding stdin',

--- a/example.js
+++ b/example.js
@@ -7,6 +7,12 @@ const spinner = new Ora({
 	spinner: process.argv[2]
 });
 
+const spinnerDiscardingStdin = new Ora({
+	discardStdin: true,
+	text: 'Loading unicorns, discarding stdin',
+	spinner: process.argv[2]
+});
+
 spinner.start();
 
 setTimeout(() => {
@@ -28,6 +34,11 @@ setTimeout(() => {
 
 setTimeout(() => {
 	spinner.succeed();
+	spinnerDiscardingStdin.start();
 }, 4000);
+
+setTimeout(() => {
+	spinnerDiscardingStdin.succeed();
+}, 7000);
 
 // $ node example.js nameOfSpinner

--- a/example.js
+++ b/example.js
@@ -3,13 +3,13 @@ const chalk = require('chalk');
 const Ora = require('.');
 
 const spinner = new Ora({
-	text: 'Loading unicorns',
+	discardStdin: false,
+	text: 'Loading unicorns, not discarding stdin',
 	spinner: process.argv[2]
 });
 
 const spinnerDiscardingStdin = new Ora({
-	discardStdin: true,
-	text: 'Loading unicorns, discarding stdin',
+	text: 'Loading unicorns',
 	spinner: process.argv[2]
 });
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -91,9 +91,9 @@ declare namespace ora {
 		readonly isEnabled?: boolean;
 
 		/**
-		Consume stdin input(except Ctrl+C) while running if it is TTY. Setting it to `true` will prevent spinner from twitching on input, outputting broken lines on `enter` presses, and prevent buffering of input for following reads or commands run after current process exits while spinner is running.
+		Discard stdin input(except Ctrl+C) while running if it is TTY. Setting it to `true` will prevent spinner from twitching on input, outputting broken lines on `enter` presses, and prevent buffering of input for following reads or commands run after current process exits while spinner is running.
 
-			@default false
+		@default false
 		*/
 		readonly discardStdin?: boolean;
 	}

--- a/index.d.ts
+++ b/index.d.ts
@@ -95,7 +95,7 @@ declare namespace ora {
 
 			@default false
 		*/
-		readonly consumeStdin?: boolean;
+		readonly discardStdin?: boolean;
 	}
 
 	interface PersistOptions {

--- a/index.d.ts
+++ b/index.d.ts
@@ -89,6 +89,13 @@ declare namespace ora {
 		Note that `{isEnabled: false}` doesn't mean it won't output anything. It just means it won't output the spinner, colors, and other ansi escape codes. It will still log text.
 		*/
 		readonly isEnabled?: boolean;
+
+		/**
+			Consume stdin input(except Ctrl+C) while running if it is TTY.
+
+			@default false
+		*/
+		readonly consumeStdin?: boolean;
 	}
 
 	interface PersistOptions {

--- a/index.d.ts
+++ b/index.d.ts
@@ -91,7 +91,7 @@ declare namespace ora {
 		readonly isEnabled?: boolean;
 
 		/**
-			Consume stdin input(except Ctrl+C) while running if it is TTY.
+		Consume stdin input(except Ctrl+C) while running if it is TTY. Setting it to `true` will prevent spinner from twitching on input, outputting broken lines on `enter` presses, and prevent buffering of input for following reads or commands run after current process exits while spinner is running.
 
 			@default false
 		*/

--- a/index.d.ts
+++ b/index.d.ts
@@ -91,9 +91,9 @@ declare namespace ora {
 		readonly isEnabled?: boolean;
 
 		/**
-		Discard stdin input(except Ctrl+C) while running if it is TTY. Setting it to `true` will prevent spinner from twitching on input, outputting broken lines on `enter` presses, and prevent buffering of input for following reads or commands run after current process exits while spinner is running.
+		Discard stdin input (except Ctrl+C) while running if it's TTY. This prevents the spinner from twitching on input, outputting broken lines on `Enter` key presses, and prevents buffering of input while the spinner is running.
 
-		@default false
+		@default true
 		*/
 		readonly discardStdin?: boolean;
 	}

--- a/index.js
+++ b/index.js
@@ -23,7 +23,7 @@ class Ora {
 			text: '',
 			color: 'cyan',
 			stream: process.stderr,
-			consumeStdin: false
+			discardStdin: false
 		}, options);
 
 		this.spinner = this.options.spinner;
@@ -40,7 +40,7 @@ class Ora {
 		this.prefixText = this.options.prefixText;
 		this.linesToClear = 0;
 		this.indent = this.options.indent;
-		this.consumeStdin = this.options.consumeStdin;
+		this.discardStdin = this.options.discardStdin;
 	}
 
 	get indent() {
@@ -173,7 +173,7 @@ class Ora {
 		this.render();
 		this.id = setInterval(this.render.bind(this), this.interval);
 
-		if (this.consumeStdin && process.stdin.isTTY) {
+		if (this.discardStdin && process.stdin.isTTY) {
 			this.startConsumingStdin();
 		}
 
@@ -193,7 +193,7 @@ class Ora {
 			cliCursor.show(this.stream);
 		}
 
-		if (this.consumeStdin && process.stdin.isTTY) {
+		if (this.discardStdin && process.stdin.isTTY) {
 			this.stopConsumingStdin();
 		}
 

--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ const PREFIX_TEXT = Symbol('prefixText');
 
 const noop = () => {};
 
-const ASCII_ETX_CODE = 0x03; // Ctrl+C emits this code in console
+const ASCII_ETX_CODE = 0x03; // Ctrl+C emits this code
 
 class Ora {
 	constructor(options) {

--- a/index.js
+++ b/index.js
@@ -212,7 +212,7 @@ class Ora {
 		stdin.on('data', noop);
 		stdin.emit = function (event, data) {
 			if (event === 'data') {
-				if (data.indexOf(0x03) !== -1) {
+				if (data.includes(0x03)) {
 					if (this.listenerCount('SIGINT') > 0) {
 						this.emit('SIGINT');
 					} else {

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -15,7 +15,7 @@ ora({indent: 1});
 ora({interval: 80});
 ora({stream: new PassThroughStream()});
 ora({isEnabled: true});
-ora({consumeStdin: true});
+ora({discardStdin: true});
 
 spinner.color = 'yellow';
 spinner.text = 'Loading rainbows';

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -15,6 +15,7 @@ ora({indent: 1});
 ora({interval: 80});
 ora({stream: new PassThroughStream()});
 ora({isEnabled: true});
+ora({consumeStdin: true});
 
 spinner.color = 'yellow';
 spinner.text = 'Loading rainbows';

--- a/readme.md
+++ b/readme.md
@@ -121,7 +121,7 @@ Note that `{isEnabled: false}` doesn't mean it won't output anything. It just me
 Type: `boolean`<br>
 Default: `true`
 
-Discard stdin input(except Ctrl+C) while running if it is TTY. Setting it to `true` prevents spinner from twitching on input, outputting broken lines on `enter` presses, and prevents buffering of input while spinner is running.
+Discard stdin input (except Ctrl+C) while running if it's TTY. This prevents the spinner from twitching on input, outputting broken lines on <kbd>Enter</kbd> key presses, and prevents buffering of input while the spinner is running.
 
 ### Instance
 

--- a/readme.md
+++ b/readme.md
@@ -116,6 +116,13 @@ Force enable/disable the spinner. If not specified, the spinner will be enabled 
 
 Note that `{isEnabled: false}` doesn't mean it won't output anything. It just means it won't output the spinner, colors, and other ansi escape codes. It will still log text.
 
+##### consumeStdin
+
+Type: `boolean`
+Default: `false`
+
+Consume stdin input(except Ctrl+C) while running if it is TTY.
+
 ### Instance
 
 #### .start([text])

--- a/readme.md
+++ b/readme.md
@@ -116,7 +116,7 @@ Force enable/disable the spinner. If not specified, the spinner will be enabled 
 
 Note that `{isEnabled: false}` doesn't mean it won't output anything. It just means it won't output the spinner, colors, and other ansi escape codes. It will still log text.
 
-##### consumeStdin
+##### discardStdin
 
 Type: `boolean`<br>
 Default: `false`

--- a/readme.md
+++ b/readme.md
@@ -121,7 +121,7 @@ Note that `{isEnabled: false}` doesn't mean it won't output anything. It just me
 Type: `boolean`<br>
 Default: `false`
 
-Consume stdin input(except Ctrl+C) while running if it is TTY. Setting it to `true` will prevent spinner from twitching on input, outputting broken lines on `enter` presses, and prevent buffering of input for following reads or commands run after current process exits while spinner is running.
+Discard stdin input(except Ctrl+C) while running if it is TTY. Setting it to `true` will prevent spinner from twitching on input, outputting broken lines on `enter` presses, and prevent buffering of input for following reads or commands run after current process exits while spinner is running.
 
 ### Instance
 

--- a/readme.md
+++ b/readme.md
@@ -121,7 +121,7 @@ Note that `{isEnabled: false}` doesn't mean it won't output anything. It just me
 Type: `boolean`<br>
 Default: `false`
 
-Consume stdin input(except Ctrl+C) while running if it is TTY.
+Consume stdin input(except Ctrl+C) while running if it is TTY. Setting it to `true` will prevent spinner from twitching on input, outputting broken lines on `enter` presses, and prevent buffering of input for following reads or commands run after current process exits while spinner is running.
 
 ### Instance
 

--- a/readme.md
+++ b/readme.md
@@ -118,7 +118,7 @@ Note that `{isEnabled: false}` doesn't mean it won't output anything. It just me
 
 ##### consumeStdin
 
-Type: `boolean`
+Type: `boolean`<br>
 Default: `false`
 
 Consume stdin input(except Ctrl+C) while running if it is TTY.

--- a/readme.md
+++ b/readme.md
@@ -119,9 +119,9 @@ Note that `{isEnabled: false}` doesn't mean it won't output anything. It just me
 ##### discardStdin
 
 Type: `boolean`<br>
-Default: `false`
+Default: `true`
 
-Discard stdin input(except Ctrl+C) while running if it is TTY. Setting it to `true` will prevent spinner from twitching on input, outputting broken lines on `enter` presses, and prevent buffering of input for following reads or commands run after current process exits while spinner is running.
+Discard stdin input(except Ctrl+C) while running if it is TTY. Setting it to `true` prevents spinner from twitching on input, outputting broken lines on `enter` presses, and prevents buffering of input while spinner is running.
 
 ### Instance
 


### PR DESCRIPTION
Add consumeStdin option, fixes #97

Though I have no idea how to write tests for it.

Plus, if some other library decides to something like what we do here, but won't be as careful as we are, things might get ugly. But that's mostly limitation of node's way of handling things.