### PR TITLE
Hide `prefixText` when it's an empty string

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -25,7 +25,7 @@ declare namespace ora {
 		readonly text?: string;
 
 		/**
-		Text to display before the spinner.
+		Text to display before the spinner. No prefix text will be displayed if set to empty string.
 		*/
 		readonly prefixText?: string;
 
@@ -105,7 +105,7 @@ declare namespace ora {
 		readonly text?: string;
 
 		/**
-		Text to be persisted before the symbol. Default: Current `prefixText`.
+		Text to be persisted before the symbol. No prefix text will be displayed if set to empty string. Default: Current `prefixText`.
 		*/
 		readonly prefixText?: string;
 	}
@@ -122,7 +122,7 @@ declare namespace ora {
 		text: string;
 
 		/**
-		Change the text before the spinner.
+		Change the text before the spinner. No prefix text will be displayed if set to empty string.
 		*/
 		prefixText: string;
 

--- a/index.js
+++ b/index.js
@@ -116,7 +116,7 @@ class Ora {
 		}
 
 		this.frameIndex = ++this.frameIndex % frames.length;
-		const fullPrefixText = typeof this.prefixText === 'string' ? this.prefixText + ' ' : '';
+		const fullPrefixText = (typeof this.prefixText === 'string' && this.prefixText !== '') ? this.prefixText + ' ' : '';
 		const fullText = typeof this.text === 'string' ? ' ' + this.text : '';
 
 		return fullPrefixText + frame + fullText;
@@ -207,7 +207,7 @@ class Ora {
 
 	stopAndPersist(options = {}) {
 		const prefixText = options.prefixText || this.prefixText;
-		const fullPrefixText = (typeof prefixText === 'string') ? prefixText + ' ' : '';
+		const fullPrefixText = (typeof prefixText === 'string' && prefixText !== '') ? prefixText + ' ' : '';
 		const text = options.text || this.text;
 		const fullText = (typeof text === 'string') ? ' ' + text : '';
 

--- a/readme.md
+++ b/readme.md
@@ -51,7 +51,7 @@ Text to display after the spinner.
 
 Type: `string`
 
-Text to display before the spinner.
+Text to display before the spinner. No prefix text will be displayed if set to empty string
 
 ##### spinner
 
@@ -174,7 +174,7 @@ Text to be persisted after the symbol
 Type: `string`<br>
 Default: Current `prefixText`
 
-Text to be persisted before the symbol.
+Text to be persisted before the symbol. No prefix text will be displayed if set to empty string
 
 <img src="screenshot-2.gif" width="480">
 
@@ -196,7 +196,7 @@ Change the text after the spinner.
 
 #### .prefixText
 
-Change the text before the spinner.
+Change the text before the spinner. No prefix text will be displayed if set to empty string
 
 #### .color
 

--- a/readme.md
+++ b/readme.md
@@ -51,7 +51,7 @@ Text to display after the spinner.
 
 Type: `string`
 
-Text to display before the spinner. No prefix text will be displayed if set to empty string
+Text to display before the spinner. No prefix text will be displayed if set to empty string.
 
 ##### spinner
 
@@ -174,7 +174,7 @@ Text to be persisted after the symbol
 Type: `string`<br>
 Default: Current `prefixText`
 
-Text to be persisted before the symbol. No prefix text will be displayed if set to empty string
+Text to be persisted before the symbol. No prefix text will be displayed if set to empty string.
 
 <img src="screenshot-2.gif" width="480">
 
@@ -196,7 +196,7 @@ Change the text after the spinner.
 
 #### .prefixText
 
-Change the text before the spinner. No prefix text will be displayed if set to empty string
+Change the text before the spinner. No prefix text will be displayed if set to empty string.
 
 #### .color
 

--- a/test.js
+++ b/test.js
@@ -318,6 +318,14 @@ test('.stopAndPersist() with prefixText', macro, spinner => {
 	spinner.stopAndPersist({symbol: '@', text: 'foo'});
 }, /bar @ foo\n$/, {prefixText: 'bar'});
 
+test('.stopAndPersist() with empty prefixText', macro, spinner => {
+	spinner.stopAndPersist({symbol: '@', text: 'foo'});
+}, /@ foo\n$/, {prefixText: ''});
+
 test('.stopAndPersist() with manual prefixText', macro, spinner => {
 	spinner.stopAndPersist({symbol: '@', prefixText: 'baz', text: 'foo'});
 }, /baz @ foo\n$/, {prefixText: 'bar'});
+
+test('.stopAndPersist() with manual empty prefixText', macro, spinner => {
+	spinner.stopAndPersist({symbol: '@', prefixText: '', text: 'foo'});
+}, /@ foo\n$/, {prefixText: 'bar'});


### PR DESCRIPTION
Fixes #122