### PR TITLE
Fix handling of Ctrl+C on spinners beyond first one

### DIFF
--- a/index.js
+++ b/index.js
@@ -221,9 +221,13 @@ class Ora {
 
 		stdin.setRawMode(true);
 		stdin.on('data', noop);
+		stdin.resume();
 
 		const self = this;
 		stdin.emit = function (event, data, ...args) {
+			if (event === 'keypress') { // Fixes readline behavior
+				return;
+			}
 			if (event === 'data' && data.includes(ASCII_ETX_CODE)) {
 				process.emit('SIGINT');
 			}

--- a/index.js
+++ b/index.js
@@ -228,6 +228,7 @@ class Ora {
 			if (event === 'keypress') { // Fixes readline behavior
 				return;
 			}
+
 			if (event === 'data' && data.includes(ASCII_ETX_CODE)) {
 				process.emit('SIGINT');
 			}


### PR DESCRIPTION
Fixes #130

This fixes the problem for now.

Multiple spinners do work and readline run in parallel works too.

But I think it wasn't broken before(when I implemented original feature) and I suspect there were some changes in nodejs code base.Need to check further to find out why exactly it is working like that now(and readline related hack with 'keypress' shouldn't be there ideally).