### PR TITLE
Fix `discardStdin` option

### DIFF
--- a/example.js
+++ b/example.js
@@ -17,6 +17,14 @@ spinnerDiscardingStdin.start();
 
 setTimeout(() => {
 	spinnerDiscardingStdin.succeed();
+}, 1000);
+
+setTimeout(() => {
+	spinnerDiscardingStdin.start();
+}, 2000);
+
+setTimeout(() => {
+	spinnerDiscardingStdin.succeed();
 	spinner.start();
 }, 3000);
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -93,7 +93,9 @@ declare namespace ora {
 		readonly isEnabled?: boolean;
 
 		/**
-		Discard stdin input (except Ctrl+C) while running if it's TTY. This prevents the spinner from twitching on input, outputting broken lines on `Enter` key presses, and prevents buffering of input while the spinner is running. Have no effect on Windows(always disabled).
+		Discard stdin input (except Ctrl+C) while running if it's TTY. This prevents the spinner from twitching on input, outputting broken lines on `Enter` key presses, and prevents buffering of input while the spinner is running.
+		
+		This has no effect on Windows as there's no good way to implement discarding stdin properly there.
 
 		@default true
 		*/

--- a/index.d.ts
+++ b/index.d.ts
@@ -93,7 +93,7 @@ declare namespace ora {
 		readonly isEnabled?: boolean;
 
 		/**
-		Discard stdin input (except Ctrl+C) while running if it's TTY. This prevents the spinner from twitching on input, outputting broken lines on `Enter` key presses, and prevents buffering of input while the spinner is running.
+		Discard stdin input (except Ctrl+C) while running if it's TTY. This prevents the spinner from twitching on input, outputting broken lines on `Enter` key presses, and prevents buffering of input while the spinner is running. Have no effect on Windows(always disabled).
 
 		@default true
 		*/

--- a/index.js
+++ b/index.js
@@ -57,6 +57,10 @@ class StdinDiscarder {
 	}
 
 	realStart() {
+		if (process.platform === 'win32') { // No known method to make it work under windows reliably
+			return;
+		}
+
 		const {stdin} = process;
 
 		this.oldRawMode = stdin.isRaw;
@@ -71,6 +75,10 @@ class StdinDiscarder {
 	}
 
 	realStop() {
+		if (process.platform === 'win32') { // No known method to make it work under windows reliably
+			return;
+		}
+
 		const {stdin} = process;
 
 		if (this.oldEmitOwnProperty) {

--- a/index.js
+++ b/index.js
@@ -62,7 +62,8 @@ class StdinDiscarder {
 	}
 
 	realStart() {
-		if (process.platform === 'win32') { // No known method to make it work under windows reliably
+		// No known way to make it work reliably on Windows
+		if (process.platform === 'win32') {
 			return;
 		}
 
@@ -82,7 +83,7 @@ class StdinDiscarder {
 	}
 
 	realStop() {
-		if (process.platform === 'win32') { // No known method to make it work under windows reliably
+		if (process.platform === 'win32') {
 			return;
 		}
 

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
 		"cli-spinners": "^2.2.0",
 		"is-interactive": "^1.0.0",
 		"log-symbols": "^3.0.0",
+		"mute-stream": "0.0.8",
 		"strip-ansi": "^5.2.0",
 		"wcwidth": "^1.0.1"
 	},

--- a/readme.md
+++ b/readme.md
@@ -122,7 +122,7 @@ Note that `{isEnabled: false}` doesn't mean it won't output anything. It just me
 Type: `boolean`<br>
 Default: `true`
 
-Discard stdin input (except Ctrl+C) while running if it's TTY. This prevents the spinner from twitching on input, outputting broken lines on <kbd>Enter</kbd> key presses, and prevents buffering of input while the spinner is running.
+Discard stdin input (except Ctrl+C) while running if it's TTY. This prevents the spinner from twitching on input, outputting broken lines on <kbd>Enter</kbd> key presses, and prevents buffering of input while the spinner is running. Have no effect on Windows(always disabled).
 
 ### Instance
 

--- a/readme.md
+++ b/readme.md
@@ -122,7 +122,9 @@ Note that `{isEnabled: false}` doesn't mean it won't output anything. It just me
 Type: `boolean`<br>
 Default: `true`
 
-Discard stdin input (except Ctrl+C) while running if it's TTY. This prevents the spinner from twitching on input, outputting broken lines on <kbd>Enter</kbd> key presses, and prevents buffering of input while the spinner is running. Have no effect on Windows(always disabled).
+Discard stdin input (except Ctrl+C) while running if it's TTY. This prevents the spinner from twitching on input, outputting broken lines on <kbd>Enter</kbd> key presses, and prevents buffering of input while the spinner is running.
+
+This has no effect on Windows as there's no good way to implement discarding stdin properly there.
 
 ### Instance
 


### PR DESCRIPTION
Disable `discardStdin` option on Windows. BTW, when using `cmd` nothing is printed anyway on Windows(unless in raw mode I suppose). Fixes #132, fixes #134, fixes #136.

Problem mostly boiled down to using raw mode twice(on separate ticks) hanged the problem under windows. Relevant change added to `example.js`(tested in `cmd`).

Make discarding work with multiple parallel `ora` instances, fixes #133.

#134 is a problem under macs too, looking into it right now.
