### PR TITLE
Add Spinnies to the list of related projects

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -258,3 +258,4 @@ JavaScript is single-threaded, so synchronous operations blocks the thread, incl
 - [briandowns/spinner](https://github.com/briandowns/spinner) - Terminal spinner/progress indicator for Go
 - [tj/go-spin](https://github.com/tj/go-spin) - Terminal spinner package for Go
 - [observablehq.com/@victordidenko/ora](https://observablehq.com/@victordidenko/ora) - Ora port to Observable notebooks
+- [spinnies](https://github.com/jcarpanelli/spinnies) - Terminal multispinner library for Node.js

--- a/readme.md
+++ b/readme.md
@@ -258,4 +258,4 @@ JavaScript is single-threaded, so synchronous operations blocks the thread, incl
 - [briandowns/spinner](https://github.com/briandowns/spinner) - Terminal spinner/progress indicator for Go
 - [tj/go-spin](https://github.com/tj/go-spin) - Terminal spinner package for Go
 - [observablehq.com/@victordidenko/ora](https://observablehq.com/@victordidenko/ora) - Ora port to Observable notebooks
-- [spinnies](https://github.com/jcarpanelli/spinnies) - Terminal multispinner library for Node.js
+- [spinnies](https://github.com/jcarpanelli/spinnies) - Terminal multi-spinner library for Node.js


### PR DESCRIPTION
Hello there! 
A couple of months ago I developed [Spinnies](https://www.npmjs.com/package/spinnies), a Node.js module to create and manage multiple spinners in command-line interface programs. This PR adds a link and a brief description of the library in the [Related](https://github.com/sindresorhus/ora#related) section in the readme.md file.