### PR TITLE
Fix undefined text on disabled Ora

### DIFF
--- a/index.js
+++ b/index.js
@@ -251,7 +251,10 @@ class Ora {
 		}
 
 		if (!this.isEnabled) {
-			this.stream.write(`- ${this.text}\n`);
+			if (this.text) {
+				this.stream.write(`- ${this.text}\n`);
+			}
+
 			return this;
 		}
 


### PR DESCRIPTION
I'm using next.js and it use Ora to show building spinner.
However, on Travis CI, there is extra `- undefined` message because of undefined text.

```
- undefined
> Using external babel configuration
- undefined
> Location: "/xxxxxxxxxxxxx/babel.config.json"
- undefined
> Using external babel configuration
- undefined
> Location: "/xxxxxxxxxxxxx/.babelrc.js"
- undefined
Creating an optimized production build

Compiled successfully.
```

After this PR:

```
> Using external babel configuration
> Location: "/xxxxxxxxxxxxx/babel.config.json"
> Using external babel configuration
> Location: "/xxxxxxxxxxxxx/.babelrc.js"
Creating an optimized production build

Compiled successfully.
```

