### PR TITLE
Update chalk to v4.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
 		"idle"
 	],
 	"dependencies": {
-		"chalk": "^3.0.0",
+		"chalk": "^4.1.0",
 		"cli-cursor": "^3.1.0",
 		"cli-spinners": "^2.2.0",
 		"is-interactive": "^1.0.0",


### PR DESCRIPTION
For many CLI applications, chalk and ora are frequently used modules, but now ora relies on chalk of ^3.0.0, which will cause these modules to use both version 3 and version 4 of chalk.