### PR TITLE
Use `bl` package instead of `mute-stream`

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ const logSymbols = require('log-symbols');
 const stripAnsi = require('strip-ansi');
 const wcwidth = require('wcwidth');
 const isInteractive = require('is-interactive');
-const MuteStream = require('mute-stream');
+const {BufferListStream} = require('bl');
 
 const TEXT = Symbol('text');
 const PREFIX_TEXT = Symbol('prefixText');
@@ -18,9 +18,8 @@ class StdinDiscarder {
 	constructor() {
 		this.requests = 0;
 
-		this.mutedStream = new MuteStream();
+		this.mutedStream = new BufferListStream();
 		this.mutedStream.pipe(process.stdout);
-		this.mutedStream.mute();
 
 		const self = this;
 		this.ourEmit = function (event, data, ...args) {

--- a/package.json
+++ b/package.json
@@ -37,12 +37,12 @@
 		"idle"
 	],
 	"dependencies": {
+		"bl": "^4.0.3",
 		"chalk": "^4.1.0",
 		"cli-cursor": "^3.1.0",
 		"cli-spinners": "^2.4.0",
 		"is-interactive": "^1.0.0",
 		"log-symbols": "^4.0.0",
-		"mute-stream": "0.0.8",
 		"strip-ansi": "^6.0.0",
 		"wcwidth": "^1.0.1"
 	},


### PR DESCRIPTION
mute-stream is abandoned, which uses legacy streams. 
Bl is a modern replacement.

Fixes #162 