### PR TITLE
Adds error var for Node 8.x compatibility

### DIFF
--- a/index.js
+++ b/index.js
@@ -398,7 +398,7 @@ module.exports.promise = (action, options) => {
 		try {
 			await action;
 			spinner.succeed();
-		} catch {
+		} catch (_) {
 			spinner.fail();
 		}
 	})();


### PR DESCRIPTION
The change [catch { }](https://github.com/sindresorhus/ora/blob/master/index.js#L401) breaks on Node 8 and it was introduced in this [commit](https://github.com/sindresorhus/ora/commit/98d3529e7e2b38c5fc91c537d299b72eb389bb7a). This PR adds an error var to stop this from happening.

On node 8:
```
try {} catch {}
             ^
SyntaxError: Unexpected token {
```

On node 12:
```
> try {} catch {}
undefined
```

