### PR TITLE
ClearLine Optimization

### DIFF
--- a/index.js
+++ b/index.js
@@ -273,7 +273,7 @@ class Ora {
 				this.stream.moveCursor(0, -1);
 			}
 			
-			if (stopping) {
+			if (isStopping) {
 				this.stream.clearLine();
 			} else {
 				this.stream.clearLine(1);

--- a/index.js
+++ b/index.js
@@ -130,6 +130,7 @@ class Ora {
 		this.indent = this.options.indent;
 		this.discardStdin = this.options.discardStdin;
 		this.isDiscardingStdin = false;
+		this.isStopping = false;
 	}
 
 	get indent() {
@@ -140,7 +141,7 @@ class Ora {
 		if (!(indent >= 0 && Number.isInteger(indent))) {
 			throw new Error('The `indent` option must be an integer from 0 and up');
 		}
-		
+
 		if (indent > this._indent) {
 			this.stream.clearLine(-1);
 		}
@@ -263,7 +264,7 @@ class Ora {
 		return fullPrefixText + frame + fullText;
 	}
 
-	clear(isStopping = false) {
+	clear() {
 		if (!this.isEnabled || !this.stream.isTTY) {
 			return this;
 		}
@@ -272,13 +273,13 @@ class Ora {
 			if (i > 0) {
 				this.stream.moveCursor(0, -1);
 			}
-			
-			if (isStopping) {
+
+			if (this.isStopping) {
 				this.stream.clearLine();
 			} else {
 				this.stream.clearLine(1);
 			}
-			
+
 			this.stream.cursorTo(this.indent);
 		}
 
@@ -343,7 +344,9 @@ class Ora {
 		clearInterval(this.id);
 		this.id = undefined;
 		this.frameIndex = 0;
-		this.clear(true);
+		this.isStopping = true;
+		this.clear();
+		this.isStopping = false;
 		if (this.hideCursor) {
 			cliCursor.show(this.stream);
 		}

--- a/index.js
+++ b/index.js
@@ -263,7 +263,7 @@ class Ora {
 		return fullPrefixText + frame + fullText;
 	}
 
-	clear(stopping = false) {
+	clear(isStopping = false) {
 		if (!this.isEnabled || !this.stream.isTTY) {
 			return this;
 		}

--- a/index.js
+++ b/index.js
@@ -140,6 +140,10 @@ class Ora {
 		if (!(indent >= 0 && Number.isInteger(indent))) {
 			throw new Error('The `indent` option must be an integer from 0 and up');
 		}
+		
+		if (indent > this._indent) {
+			this.stream.clearLine(-1);
+		}
 
 		this._indent = indent;
 	}
@@ -259,7 +263,7 @@ class Ora {
 		return fullPrefixText + frame + fullText;
 	}
 
-	clear() {
+	clear(stopping = false) {
 		if (!this.isEnabled || !this.stream.isTTY) {
 			return this;
 		}
@@ -268,8 +272,13 @@ class Ora {
 			if (i > 0) {
 				this.stream.moveCursor(0, -1);
 			}
-
-			this.stream.clearLine();
+			
+			if (stopping) {
+				this.stream.clearLine();
+			} else {
+				this.stream.clearLine(1);
+			}
+			
 			this.stream.cursorTo(this.indent);
 		}
 
@@ -334,7 +343,7 @@ class Ora {
 		clearInterval(this.id);
 		this.id = undefined;
 		this.frameIndex = 0;
-		this.clear();
+		this.clear(true);
 		if (this.hideCursor) {
 			cliCursor.show(this.stream);
 		}


### PR DESCRIPTION
It is only necessary to call `this.stream.clearLine()` when `clear` is called in the `stop` method, otherwise clearing just to the right of the cursor (with `this.stream.clearLine(1)`) is sufficient. (See: https://stackoverflow.com/a/59805130)

While that might not seem like a big change, this resolves flickering issues in Windows that occur with many 'emulated' (if that's the correct term) shells I tested (See: sindresorhus#140). That includes WSL, all shells running under Windows Terminal, all shells running under Terminus, Powershell under Alacritty (which uses an OpenGL renderer), among others. No idea at all what the common thread could be. Plain old Powershell has no flickering issues, vanilla CMD stutters sometimes but is largely fine.  Cmder stands out as having no flickering issues, at least with the shells I tested. 

In any case, a call to `this.stream.clearLine(-1)` when indentation changes (to be greater) is needed, otherwise no other changes seem to be necessary. All tests pass.