### PR TITLE
Use nice spinner on VSCode's terminal and Windows Terminal

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,11 +13,11 @@ const TEXT = Symbol('text');
 const PREFIX_TEXT = Symbol('prefixText');
 
 const ASCII_ETX_CODE = 0x03; // Ctrl+C emits this code
-const terminalSupportsUnicode = function() {
-	return process.platform !== 'win32'
-	|| process.env.TERM_PROGRAM === 'vscode'
-	|| !!process.env.WT_SESSION
-}
+const terminalSupportsUnicode = function () {
+	return process.platform !== 'win32' ||
+	process.env.TERM_PROGRAM === 'vscode' ||
+	Boolean(process.env.WT_SESSION);
+};
 
 class StdinDiscarder {
 	constructor() {

--- a/index.js
+++ b/index.js
@@ -13,6 +13,11 @@ const TEXT = Symbol('text');
 const PREFIX_TEXT = Symbol('prefixText');
 
 const ASCII_ETX_CODE = 0x03; // Ctrl+C emits this code
+const terminalSupportsUnicode = function() {
+	return process.platform !== 'win32'
+	|| process.env.TERM_PROGRAM === 'vscode'
+	|| !!process.env.WT_SESSION
+}
 
 class StdinDiscarder {
 	constructor() {
@@ -163,7 +168,7 @@ class Ora {
 			}
 
 			this._spinner = spinner;
-		} else if (process.platform === 'win32') {
+		} else if (!terminalSupportsUnicode()) {
 			this._spinner = cliSpinners.line;
 		} else if (spinner === undefined) {
 			// Set default spinner

--- a/index.js
+++ b/index.js
@@ -13,11 +13,12 @@ const TEXT = Symbol('text');
 const PREFIX_TEXT = Symbol('prefixText');
 
 const ASCII_ETX_CODE = 0x03; // Ctrl+C emits this code
-const terminalSupportsUnicode = function () {
-	return process.platform !== 'win32' ||
+
+const terminalSupportsUnicode = () => (
+	process.platform !== 'win32' ||
 	process.env.TERM_PROGRAM === 'vscode' ||
 	Boolean(process.env.WT_SESSION);
-};
+);
 
 class StdinDiscarder {
 	constructor() {

--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ const ASCII_ETX_CODE = 0x03; // Ctrl+C emits this code
 const terminalSupportsUnicode = () => (
 	process.platform !== 'win32' ||
 	process.env.TERM_PROGRAM === 'vscode' ||
-	Boolean(process.env.WT_SESSION);
+	Boolean(process.env.WT_SESSION)
 );
 
 class StdinDiscarder {


### PR DESCRIPTION
Best guess of whether win32-based platforms support Unicode in the console

Fixes #159