### PR TITLE
Changes to render behavior

### DIFF
--- a/index.js
+++ b/index.js
@@ -148,6 +148,7 @@ class Ora {
 		}
 
 		this._indent = indent;
+		this.updateLineCount();
 	}
 
 	_updateInterval(interval) {
@@ -221,7 +222,7 @@ class Ora {
 		const columns = this.stream.columns || 80;
 		const fullPrefixText = this.getFullPrefixText(this.prefixText, '-');
 		this.lineCount = 0;
-		for (const line of stripAnsi(fullPrefixText + '--' + this[TEXT]).split('\n')) {
+		for (const line of stripAnsi(' '.repeat(this.indent) + fullPrefixText + '--' + this[TEXT]).split('\n')) {
 			this.lineCount += Math.max(1, Math.ceil(wcwidth(line) / columns));
 		}
 	}
@@ -270,14 +271,17 @@ class Ora {
 			return this;
 		}
 
+		this.stream.cursorTo(0);
+
 		for (let i = 0; i < this.linesToClear; i++) {
 			if (i > 0) {
 				this.stream.moveCursor(0, -1);
 			}
 
-			this.stream.clearLine();
-			this.stream.cursorTo(this.indent);
+			this.stream.clearLine(1);
 		}
+
+		this.stream.cursorTo(this.indent);
 
 		this.linesToClear = 0;
 


### PR DESCRIPTION
- Unless I'm missing something, I would think an increase to indent, when combined with prefixText + text, could certainly increase the combined width over the number of columns, so it should be factored in to the lineCount calculations

- Updated clear method, which again fixes flickering in windows terminals, but this time also clears everything on the line successfully between renders (unlike the last attempt).

Regarding tests, it was necessary for me to create some tools to effectively test changes to the clear method, and I've put them and the tests here [https://github.com/moofoo/ora_tests](https://github.com/moofoo/ora_tests)