### PR TITLE
Fix line wrapping issues with large values for `spinner.indent`

### DIFF
--- a/index.js
+++ b/index.js
@@ -148,6 +148,7 @@ class Ora {
 		}
 
 		this._indent = indent;
+		this.updateLineCount();
 	}
 
 	_updateInterval(interval) {
@@ -221,7 +222,7 @@ class Ora {
 		const columns = this.stream.columns || 80;
 		const fullPrefixText = this.getFullPrefixText(this.prefixText, '-');
 		this.lineCount = 0;
-		for (const line of stripAnsi(fullPrefixText + '--' + this[TEXT]).split('\n')) {
+		for (const line of stripAnsi(' '.repeat(this.indent) + fullPrefixText + '--' + this[TEXT]).split('\n')) {
 			this.lineCount += Math.max(1, Math.ceil(wcwidth(line) / columns));
 		}
 	}

--- a/test.js
+++ b/test.js
@@ -359,6 +359,27 @@ test('indent option throws', t => {
 	}, 'The `indent` option must be an integer from 0 and up');
 });
 
+test('handles wrapped lines when length of indent + text is greater than columns', t => {
+	const stream = getPassThroughStream();
+	stream.isTTY = true;
+	stream.columns = 20;
+
+	const spinner = new Ora({
+		stream,
+		text: 'foo',
+		color: false,
+		isEnabled: true
+	});
+
+	spinner.render();
+
+	spinner.text = '0'.repeat(spinner.stream.columns - 5);
+	spinner.indent = 15;
+	spinner.render();
+
+	t.is(spinner.lineCount, 2);
+});
+
 test('.stopAndPersist() with prefixText', macro, spinner => {
 	spinner.stopAndPersist({symbol: '@', text: 'foo'});
 }, /bar @ foo\n$/, {prefixText: 'bar'});


### PR DESCRIPTION
Here is a test that demonstrates the issue: https://github.com/moofoo/ora/blob/indent-issue/test.js

changes:
- including spinner.indent in the calculation of lineCount
- calling updateLineCount in indent setter