### PR TITLE
Improvement performance of the `.clear()` method

### DIFF
--- a/index.js
+++ b/index.js
@@ -271,14 +271,21 @@ class Ora {
 			return this;
 		}
 
+		this.stream.cursorTo(0);
+
 		for (let i = 0; i < this.linesToClear; i++) {
 			if (i > 0) {
 				this.stream.moveCursor(0, -1);
 			}
 
-			this.stream.clearLine();
+			this.stream.clearLine(1);
+		}
+
+		if (this.indent || this.lastIndent !== this.indent) {
 			this.stream.cursorTo(this.indent);
 		}
+
+		this.lastIndent = this.indent;
 
 		this.linesToClear = 0;
 

--- a/index.js
+++ b/index.js
@@ -148,6 +148,7 @@ class Ora {
 		}
 
 		this._indent = indent;
+		this.updateLineCount();
 	}
 
 	_updateInterval(interval) {
@@ -221,7 +222,7 @@ class Ora {
 		const columns = this.stream.columns || 80;
 		const fullPrefixText = this.getFullPrefixText(this.prefixText, '-');
 		this.lineCount = 0;
-		for (const line of stripAnsi(fullPrefixText + '--' + this[TEXT]).split('\n')) {
+		for (const line of stripAnsi(' '.repeat(this.indent) + fullPrefixText + '--' + this[TEXT]).split('\n')) {
 			this.lineCount += Math.max(1, Math.ceil(wcwidth(line) / columns));
 		}
 	}

--- a/test.js
+++ b/test.js
@@ -359,6 +359,27 @@ test('indent option throws', t => {
 	}, 'The `indent` option must be an integer from 0 and up');
 });
 
+test('handles wrapped lines when length of indent + text is greater than columns', t => {
+	const stream = getPassThroughStream();
+	stream.isTTY = true;
+	stream.columns = 20;
+
+	const spinner = new Ora({
+		stream,
+		text: 'foo',
+		color: false,
+		isEnabled: true
+	});
+
+	spinner.render();
+
+	spinner.text = '0'.repeat(spinner.stream.columns - 5);
+	spinner.indent = 15;
+	spinner.render();
+
+	t.is(spinner.lineCount, 2);
+});
+
 test('.stopAndPersist() with prefixText', macro, spinner => {
 	spinner.stopAndPersist({symbol: '@', text: 'foo'});
 }, /bar @ foo\n$/, {prefixText: 'bar'});


### PR DESCRIPTION
cursorTo is called the minimal number of times necessary: to set the cursor position to the start of the line to set up the clearLine(1) loop, and after the loop to reset the cursor (if necessary)

clearLine(0) and clearLine(-1) cause flickering issues in Windows terminals when executed on an interval. Using clearLine(1) resolves this issue.

Tests can be found [here](https://github.com/moofoo/ora/blob/9768c336b4a6064e0f02c2471ccbc1ab25dfd1d7/test.js#L615)