### PR TITLE
Don't allow `default` as a spinner

### DIFF
--- a/index.js
+++ b/index.js
@@ -168,7 +168,7 @@ class Ora {
 		} else if (spinner === undefined) {
 			// Set default spinner
 			this._spinner = cliSpinners.dots;
-		} else if (cliSpinners[spinner]) {
+		} else if (spinner !== 'default' && cliSpinners[spinner]) {
 			this._spinner = cliSpinners[spinner];
 		} else {
 			throw new Error(`There is no built-in spinner named '${spinner}'. See https://github.com/sindresorhus/cli-spinners/blob/main/spinners.json for a full list.`);

--- a/test.js
+++ b/test.js
@@ -322,8 +322,10 @@ if (process.platform !== 'win32') {
 	});
 }
 
-test('throw when spinner is set to "default"', t => {
-	t.throws(() => new Ora({spinner: 'default'}), /no built-in spinner/);
+test('throw when spinner is set to `default`', t => {
+	t.throws(() => {
+		new Ora({spinner: 'default'});
+	}, /no built-in spinner/);
 });
 
 test('indent option', t => {

--- a/test.js
+++ b/test.js
@@ -322,6 +322,10 @@ if (process.platform !== 'win32') {
 	});
 }
 
+test('throw when spinner is set to "default"', t => {
+	t.throws(() => new Ora({spinner: 'default'}), /no built-in spinner/);
+});
+
 test('indent option', t => {
 	const stream = getPassThroughStream();
 	stream.isTTY = true;

--- a/test.js
+++ b/test.js
@@ -324,7 +324,7 @@ if (process.platform !== 'win32') {
 
 test('throw when spinner is set to `default`', t => {
 	t.throws(() => {
-		new Ora({spinner: 'default'});
+		new Ora({spinner: 'default'}); // eslint-disable-line no-new
 	}, /no built-in spinner/);
 });
 


### PR DESCRIPTION
Hello 👋 

Thank you for this great tool ❤️ 

I spotted this bug while working on https://github.com/netlify/cli/pull/2576.

Currently `'default'` passes the validation while not being a valid spinner name.