### PR TITLE
Close readline in `StdinDiscarder` without changing stdin's pause state

### DIFF
--- a/utilities.js
+++ b/utilities.js
@@ -79,7 +79,17 @@ export class StdinDiscarder {
 			return;
 		}
 
+		const {stdin} = process;
+		const wasPaused = stdin.isPaused();
+
 		this.#rl.close();
+
+		// Keep stdin unpaused across the readline close if it is already
+		// unpaused. See #209 for more details.
+		if (!wasPaused && stdin.isPaused()) {
+			stdin.resume();
+		}
+
 		this.#rl = undefined;
 	}
 }


### PR DESCRIPTION
Patches the close in `StdinDiscarder` to keep stdin unpaused if it was already in that state. `readline.close()` has the undocumented side-effect of pausing the input stream, in this case `stdin`.

Fixes #209.