### PR TITLE
Export `cliSpinners` as `spinners`

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -306,3 +306,5 @@ export function oraPromise<T>(
 	action: PromiseLike<T> | ((spinner: Ora) => PromiseLike<T>),
 	options?: string | PromiseOptions<T>
 ): Promise<T>;
+
+export {default as spinners} from 'cli-spinners';

--- a/index.js
+++ b/index.js
@@ -378,3 +378,5 @@ export async function oraPromise(action, options) {
 		throw error;
 	}
 }
+
+export {default as spinners} from 'cli-spinners';

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -1,6 +1,7 @@
 import {PassThrough as PassThroughStream} from 'node:stream';
 import {expectType} from 'tsd';
-import ora, {oraPromise} from './index.js';
+import cliSpinners from 'cli-spinners';
+import ora, {oraPromise, spinners} from './index.js';
 
 const spinner = ora('Loading unicorns');
 ora({text: 'Loading unicorns'});
@@ -68,3 +69,5 @@ void oraPromise(async spinner => {
 	successText: result => `Resolved with number ${result}`,
 	failText: 'bar',
 });
+
+expectType<typeof cliSpinners>(spinners);

--- a/readme.md
+++ b/readme.md
@@ -55,7 +55,7 @@ Text or a function that returns text to display before the spinner. No prefix te
 Type: `string | object`\
 Default: `'dots'` <img src="screenshot-spinner.gif" width="14">
 
-Name of one of the [provided spinners](https://github.com/sindresorhus/cli-spinners/blob/main/spinners.json). See `example.js` in this repo if you want to test out different spinners. On Windows, it will always use the `line` spinner as the Windows command-line doesn't have proper Unicode support.
+Name of one of the [provided spinners](#spinners). See `example.js` in this repo if you want to test out different spinners. On Windows, it will always use the `line` spinner as the Windows command-line doesn't have proper Unicode support.
 
 Or an object like:
 
@@ -267,6 +267,12 @@ Type: `string | ((error: Error) => string) | undefined`
 The new text of the spinner when the promise is rejected.
 
 Keeps the existing text if `undefined`.
+
+### spinners
+
+Type: `Record<string, Spinner>`
+
+All [provided spinners](https://github.com/sindresorhus/cli-spinners/blob/main/spinners.json).
 
 ## FAQ
 

--- a/test.js
+++ b/test.js
@@ -4,8 +4,7 @@ import getStream from 'get-stream';
 import test from 'ava';
 import stripAnsi from 'strip-ansi';
 import TransformTTY from 'transform-tty';
-import cliSpinners from 'cli-spinners';
-import ora, {oraPromise} from './index.js';
+import ora, {oraPromise, spinners} from './index.js';
 
 const spinnerCharacter = process.platform === 'win32' ? '-' : '⠋';
 const noop = () => {};
@@ -666,7 +665,7 @@ test('new clear method, stress test', t => {
 	const randos = () => rAnDoMaNiMaLs(rando(5, 15), rando(25, 50));
 
 	const randomize = (s1, s2) => {
-		const spnr = cliSpinners.random;
+		const spnr = spinners.random;
 		const txt = randos();
 		const indent = rando(0, 15);
 


### PR DESCRIPTION
Closes #217.

Reexports `cliSpinners` as `spinners` and adds to types (with test), updates a test, and documents in the readme.