### PR TITLE
Added string-width to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
 		"is-unicode-supported": "^1.3.0",
 		"log-symbols": "^5.1.0",
 		"stdin-discarder": "^0.1.0",
+		"string-width": "^6.1.0",
 		"strip-ansi": "^7.1.0"
 	},
 	"devDependencies": {


### PR DESCRIPTION
# Problem

`ora@7.0.0` uses the `string-width` package, but doesn't include it as a dependency or peer-dependency.

# Implication

Users that install & import the latest version of `ora` for the first time will run into the following runtime error if `string-width` isn't specifically listed as a dependency or required by any other dependencies.

```bash
node:internal/modules/cjs/loader:1077
const err = new Error(message);
            ^
Error: Cannot find module 'string-width'
...
```

This error is caused by Line 7 in `node_modules/ora/index.js`

```js
import stringWidth from "string-width";
```

# Solution

Add `string-width` as a dependency or peer-dependency in ora's `package.json`.

```package.json
{
  "name": "ora",
  ...
  "dependencies": {
    ...
    "string-width": "^6.1.0"
  }
}
```

# Problem & Solution Tested On

- Mac OS X Ventura
- Debian Linux 12 Bookworm
- Node v18.7.0
- Node v20.5.0

# Last Working Version

- The previous release (`ora@6.3.1`) works as expected as it doesn't depend on or import the `string-width` package.
