### PR TITLE
Bug fix/writable stream validator

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,6 +34,10 @@ class Ora {
 			};
 		}
 
+		if (options?.stream && typeof options.stream.write !== 'function') {
+			throw new TypeError('Stream must be a writable stream');
+		}
+
 		this.#options = {
 			color: 'cyan',
 			stream: process.stderr,

--- a/test.js
+++ b/test.js
@@ -679,6 +679,16 @@ test('new clear method test, erases wrapped lines', t => {
 	t.deepEqual(frames, currentFrames);
 });
 
+test('should throw TypeError when a non-writable stream is passed', t => {
+	const nonWritableStream = {};
+
+	const error = t.throws(_ => ora({stream: nonWritableStream}), {
+		instanceOf: TypeError,
+	});
+
+	t.is(error.message, 'Stream must be a writable stream');
+});
+
 test('new clear method, stress test', t => {
 	const rando = (min, max) => {
 		min = Math.ceil(min);


### PR DESCRIPTION
## Bug Explanation: Invalid Stream Type for Ora Spinner

### Summary
The `ora` library requires that the `stream` option passed during spinner initialization be a writable stream. If a non-writable stream or an object that lacks a `write` method is provided, it throws a `TypeError`.

### Reproduction Steps
1. Import the `ora` library.
2. Create an object that does not have a `write` method (e.g., a plain object or a read-only stream).
3. Attempt to initialize `ora` with this object as the `stream` option.

### Example Code
```javascript
const ora = require('ora');
const myStream = {}; // Non-writable stream
const spinner = ora({ stream: myStream });

The above code will return an unhandled exception 


**Fix**

if (options?.stream && typeof options.stream.write !== "function") {
    throw new TypeError("Stream must be a writable stream");
}

This check indicates that the ora spinner accepts a stream option, which should be a writable stream. The bug arises when the provided stream option does not conform to this expectation. A common real-world scenario that can lead to this issue is passing a non-writable stream (like a read-only stream) to the ora instance.