### PR TITLE
fix: prevent extra leading whitespace in stopAndPersist when symbol i…

### DIFF
--- a/index.js
+++ b/index.js
@@ -358,7 +358,8 @@ class Ora {
 		const symbolText = options.symbol ?? ' ';
 
 		const text = options.text ?? this.text;
-		const fullText = (typeof text === 'string') ? ' ' + text : '';
+		const separatorText = symbolText ? ' ' : '';
+		const fullText = (typeof text === 'string') ? separatorText + text : '';
 
 		const suffixText = options.suffixText ?? this.#suffixText;
 		const fullSuffixText = this.#getFullSuffixText(suffixText, ' ');


### PR DESCRIPTION
**Summary**
When using stopAndPersist with { symbol: '', text: 'text...' }, an extra leading whitespace appears before the text in the terminal.

**Example Code**
```
import ora from 'ora';

const spinner = ora().start('Ora Start');

setTimeout(() => {
  spinner.stopAndPersist({ symbol: '', text: 'Ora Stop' });
}, 1000);
```