### PR TITLE
Add support for `boolean` value for `color` option

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -58,7 +58,7 @@ export type Options = {
 
 	@default 'cyan'
 	*/
-	readonly color?: Color;
+	readonly color?: Color | boolean;
 
 	/**
 	Set to `false` to stop Ora from hiding the cursor.

--- a/index.d.ts
+++ b/index.d.ts
@@ -186,7 +186,7 @@ export interface Ora {
 	/**
 	Change the spinner color.
 	*/
-	color: Color;
+	color: Color | boolean;
 
 	/**
 	Change the spinner indent.

--- a/readme.md
+++ b/readme.md
@@ -76,9 +76,9 @@ Or an object like:
 
 ##### color
 
-Type: `string`\
+Type: `string | boolean`\
 Default: `'cyan'`\
-Values: `'black' | 'red' | 'green' | 'yellow' | 'blue' | 'magenta' | 'cyan' | 'white' | 'gray'`
+Values: `'black' | 'red' | 'green' | 'yellow' | 'blue' | 'magenta' | 'cyan' | 'white' | 'gray' | false`
 
 The color of the spinner.
 

--- a/readme.md
+++ b/readme.md
@@ -78,7 +78,7 @@ Or an object like:
 
 Type: `string | boolean`\
 Default: `'cyan'`\
-Values: `'black' | 'red' | 'green' | 'yellow' | 'blue' | 'magenta' | 'cyan' | 'white' | 'gray' | false`
+Values: `'black' | 'red' | 'green' | 'yellow' | 'blue' | 'magenta' | 'cyan' | 'white' | 'gray' | boolean`
 
 The color of the spinner.
 


### PR DESCRIPTION
color property of class Ora can be a boolean `false` when the default color and chalk color application will not occur, but the type hint only mentions `Color` whereas it should be `Color | boolean`.