### PR TITLE
Replace chalk with picocolors, update docs

### DIFF
--- a/example.js
+++ b/example.js
@@ -1,5 +1,5 @@
 import process from 'node:process';
-import chalk from 'chalk';
+import pc from 'picocolors';
 import logSymbols from 'log-symbols';
 import ora from './index.js';
 
@@ -31,7 +31,7 @@ setTimeout(() => {
 
 setTimeout(() => {
 	spinner.color = 'yellow';
-	spinner.text = `Loading ${chalk.red('rainbows')}`;
+	spinner.text = `Loading ${pc.red('rainbows')}`;
 }, 4000);
 
 setTimeout(() => {
@@ -47,20 +47,20 @@ setTimeout(() => {
 }, 6000);
 
 setTimeout(() => {
-	spinner.prefixText = chalk.dim('[info]');
+	spinner.prefixText = pc.dim('[info]');
 	spinner.spinner = 'dots';
 	spinner.text = 'Loading with prefix text';
 }, 8000);
 
 setTimeout(() => {
 	spinner.prefixText = '';
-	spinner.suffixText = chalk.dim('[info]');
+	spinner.suffixText = pc.dim('[info]');
 	spinner.text = 'Loading with suffix text';
 }, 10_000);
 
 setTimeout(() => {
-	spinner.prefixText = chalk.dim('[info]');
-	spinner.suffixText = chalk.dim('[info]');
+	spinner.prefixText = pc.dim('[info]');
+	spinner.suffixText = pc.dim('[info]');
 	spinner.text = 'Loading with prefix and suffix text';
 }, 12_000);
 

--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 import process from 'node:process';
-import chalk from 'chalk';
+import pc from 'picocolors';
 import cliCursor from 'cli-cursor';
 import cliSpinners from 'cli-spinners';
 import logSymbols from 'log-symbols';
@@ -235,7 +235,7 @@ class Ora {
 		let frame = frames[this.#frameIndex];
 
 		if (this.color) {
-			frame = chalk[this.color](frame);
+			frame = pc[this.color](frame);
 		}
 
 		const fullPrefixText = (typeof this.#prefixText === 'string' && this.#prefixText !== '') ? this.#prefixText + ' ' : '';

--- a/package.json
+++ b/package.json
@@ -43,12 +43,12 @@
 		"idle"
 	],
 	"dependencies": {
-		"chalk": "^5.3.0",
 		"cli-cursor": "^5.0.0",
 		"cli-spinners": "^2.9.2",
 		"is-interactive": "^2.0.0",
 		"is-unicode-supported": "^2.0.0",
 		"log-symbols": "^6.0.0",
+		"picocolors": "^1.1.1",
 		"stdin-discarder": "^0.2.2",
 		"string-width": "^7.2.0",
 		"strip-ansi": "^7.1.0"

--- a/readme.md
+++ b/readme.md
@@ -299,13 +299,22 @@ All [provided spinners](https://github.com/sindresorhus/cli-spinners/blob/main/s
 
 ### How do I change the color of the text?
 
-Use [`chalk`](https://github.com/chalk/chalk) or [`yoctocolors`](https://github.com/sindresorhus/yoctocolors):
+If you use Node.js v20.12.0 or later, use the built-in [`util.styleText`](https://nodejs.org/api/util.html#utilstyletextformat-text-options):
+
+```js
+import { styleText } from 'node:util';
+import ora from 'ora';
+
+const spinner = ora(`Loading ${styleText('red', 'unicorns')}`).start();
+```
+
+On older versions of Node.js, use [`picocolors`](https://github.com/alexeyraspopov/picocolors), [`chalk`](https://github.com/chalk/chalk), or [`yoctocolors`](https://github.com/sindresorhus/yoctocolors):
 
 ```js
 import ora from 'ora';
-import chalk from 'chalk';
+import pc from 'picocolors';
 
-const spinner = ora(`Loading ${chalk.red('unicorns')}`).start();
+const spinner = ora(`Loading ${pc.red('unicorns')}`).start();
 ```
 
 ### Why does the spinner freeze?

--- a/test.js
+++ b/test.js
@@ -983,3 +983,27 @@ Example output:
   ... 1 more item
 ]
 */
+
+const colors = [
+	'black',
+	'red',
+	'green',
+	'yellow',
+	'blue',
+	'magenta',
+	'cyan',
+	'white',
+	'gray',
+];
+
+test('does not crash with any of available colors', t => {
+	for (const color of colors) {
+		t.notThrows(() => {
+			const spinner = ora({color});
+
+			spinner.render();
+			spinner.clear();
+			spinner.stop();
+		});
+	}
+});


### PR DESCRIPTION
This PR replaces `chalk` with `picocolors` and updates docs to teach about built-in `util.styleText` and `picocolors`.

It also adds unit tests to ensure that ora can indeed render with any of the available colors.