### PR TITLE
refactor: replace strip-ansi with native stripVTControlCharacters

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,9 +1,9 @@
 import process from 'node:process';
+import {stripVTControlCharacters} from 'node:util';
 import chalk from 'chalk';
 import cliCursor from 'cli-cursor';
 import cliSpinners from 'cli-spinners';
 import logSymbols from 'log-symbols';
-import stripAnsi from 'strip-ansi';
 import stringWidth from 'string-width';
 import isInteractive from 'is-interactive';
 import isUnicodeSupported from 'is-unicode-supported';
@@ -186,7 +186,7 @@ class Ora {
 
 	#computeLineCountFrom(text, columns) {
 		let count = 0;
-		for (const line of stripAnsi(text).split('\n')) {
+		for (const line of stripVTControlCharacters(text).split('\n')) {
 			count += Math.max(1, Math.ceil(stringWidth(line) / columns));
 		}
 

--- a/package.json
+++ b/package.json
@@ -50,8 +50,7 @@
 		"is-unicode-supported": "^2.1.0",
 		"log-symbols": "^7.0.1",
 		"stdin-discarder": "^0.2.2",
-		"string-width": "^8.1.0",
-		"strip-ansi": "^7.1.2"
+		"string-width": "^8.1.0"
 	},
 	"devDependencies": {
 		"@types/node": "^24.5.0",

--- a/test.js
+++ b/test.js
@@ -1,9 +1,9 @@
 import process from 'node:process';
 import {PassThrough as PassThroughStream} from 'node:stream';
+import {stripVTControlCharacters} from 'node:util';
 import assert from 'node:assert/strict';
 import test from 'node:test';
 import getStream from 'get-stream';
-import stripAnsi from 'strip-ansi';
 import TransformTTY from 'transform-tty';
 import ora, {oraPromise, spinners} from './index.js';
 
@@ -35,7 +35,7 @@ const doSpinner = async (function_, extraOptions = {}) => {
 	function_(spinner);
 	stream.end();
 
-	return stripAnsi(await output);
+	return stripVTControlCharacters(await output);
 };
 
 test('main', async () => {
@@ -186,7 +186,7 @@ test('oraPromise() - resolves', async () => {
 	await resolves;
 	stream.end();
 
-	assert.match(stripAnsi(await output), /[√✔] foo\n$/);
+	assert.match(stripVTControlCharacters(await output), /[√✔] foo\n$/);
 });
 
 test('oraPromise() - rejects', async () => {
@@ -205,7 +205,7 @@ test('oraPromise() - rejects', async () => {
 
 	stream.end();
 
-	assert.match(stripAnsi(await output), /[×✖] foo\n$/);
+	assert.match(stripVTControlCharacters(await output), /[×✖] foo\n$/);
 });
 
 test('erases wrapped lines', () => {
@@ -322,7 +322,7 @@ test('reset frameIndex when setting new spinner', async () => {
 	stream.end();
 
 	assert.strictEqual(spinner._frameIndex, 0);
-	assert.match(stripAnsi(await output), /foo baz/);
+	assert.match(stripVTControlCharacters(await output), /foo baz/);
 });
 
 test('set the correct interval when changing spinner (object case)', () => {
@@ -590,7 +590,7 @@ test('oraPromise(function) passes spinner and supports successText function', as
 	});
 
 	stream.end();
-	assert.match(stripAnsi(await output), /[√✔] done: 7\n$/);
+	assert.match(stripVTControlCharacters(await output), /[√✔] done: 7\n$/);
 });
 
 test('oraPromise(function) rejects and supports failText function', async () => {
@@ -611,7 +611,7 @@ test('oraPromise(function) rejects and supports failText function', async () => 
 	} catch {}
 
 	stream.end();
-	assert.match(stripAnsi(await output), /[×✖] oops: boom\n$/);
+	assert.match(stripVTControlCharacters(await output), /[×✖] oops: boom\n$/);
 });
 
 test('oraPromise() validates `action` type', async () => {
@@ -710,7 +710,7 @@ test('start() with empty text and isEnabled:false produces no output', async () 
 	spinner.start();
 	stream.end();
 
-	const text = stripAnsi(await output);
+	const text = stripVTControlCharacters(await output);
 	assert.match(text, /^(?![\s\S])/);
 });
 
@@ -1495,7 +1495,7 @@ test('disabled spinner preserves prefix/suffix/indent', async () => {
 	spinner.start();
 	stream.end();
 
-	const text = stripAnsi(await output);
+	const text = stripVTControlCharacters(await output);
 	assert.strictEqual(text, '  pre - test post\n');
 });
 


### PR DESCRIPTION
## Summary

- Replace `strip-ansi` dependency with Node.js built-in `util.stripVTControlCharacters()`
- Remove `strip-ansi` from dependencies

## Rationale

The `stripVTControlCharacters` function has been available in Node.js since v16.11, and ora already requires Node.js >= 20. Using the native API eliminates an external dependency and its transitive dependencies.

This is the same change pattern as [string-length#21](https://github.com/sindresorhus/string-length/pull/21).