### PR TITLE
chore: removed "chalk" in favor of node:utils's styleText

### DIFF
--- a/example-console-integration.js
+++ b/example-console-integration.js
@@ -1,9 +1,9 @@
-import chalk from 'chalk';
+import { styleText } from 'node:util';
 import ora from './index.js';
 
-console.log(chalk.bold('\n🦄 Unicorn Console Integration Demo\n'));
-console.log(chalk.dim('This example shows how ora seamlessly handles console.error/warn'));
-console.log(chalk.dim('while the spinner is running. These write to stderr where ora hooks!\n'));
+console.log(styleText('bold', '\n🦄 Unicorn Console Integration Demo\n'));
+console.log(styleText('dim', 'This example shows how ora seamlessly handles console.error/warn'));
+console.log(styleText('dim', 'while the spinner is running. These write to stderr where ora hooks!\n'));
 
 // Simulate collecting unicorns with status updates
 const collectUnicorns = ora({
@@ -12,27 +12,28 @@ const collectUnicorns = ora({
 }).start();
 
 setTimeout(() => {
-	console.error(chalk.cyan('✨ Found a baby unicorn near the crystal stream!'));
+	console.error(styleText('cyan', '✨ Found a baby unicorn near the crystal stream!'));
 }, 500);
 
 setTimeout(() => {
-	console.error(chalk.yellow('✨ Spotted a golden unicorn on the rainbow bridge!'));
+	console.error(styleText('yellow', '✨ Spotted a golden unicorn on the rainbow bridge!'));
 }, 1000);
 
 setTimeout(() => {
-	console.warn(chalk.hex('#FFA500')('⚠️  A wild unicorn is shy and hiding behind clouds'));
+	// mapped #FFA500 -> yellowBright
+	console.warn(styleText('yellowBright', '⚠️  A wild unicorn is shy and hiding behind clouds'));
 }, 1500);
 
 setTimeout(() => {
-	console.error(chalk.magenta('✨ Discovered a unicorn herd in the meadow!'));
+	console.error(styleText('magenta', '✨ Discovered a unicorn herd in the meadow!'));
 }, 2000);
 
 setTimeout(() => {
-	console.error(chalk.red('❌ Dark forest area is too dangerous to explore'));
+	console.error(styleText('red', '❌ Dark forest area is too dangerous to explore'));
 }, 2500);
 
 setTimeout(() => {
-	collectUnicorns.succeed(chalk.green('Collected 3 magical unicorns! 🦄🦄🦄'));
+	collectUnicorns.succeed(styleText(['bold', 'green'], 'Collected 3 magical unicorns! 🦄🦄🦄'));
 
 	// Start processing unicorn magic
 	const processSpinner = ora({
@@ -41,19 +42,19 @@ setTimeout(() => {
 	}).start();
 
 	setTimeout(() => {
-		console.error(chalk.blue('🌟 Converting stardust to rainbow essence'));
+		console.error(styleText('blue', '🌟 Converting stardust to rainbow essence'));
 	}, 500);
 
 	setTimeout(() => {
-		console.error(chalk.magenta('🌈 Brewing magical unicorn potion'));
+		console.error(styleText('magenta', '🌈 Brewing magical unicorn potion'));
 	}, 1000);
 
 	setTimeout(() => {
-		console.error(chalk.yellow('✨ Enchanting unicorn horn fragments'));
+		console.error(styleText('yellow', '✨ Enchanting unicorn horn fragments'));
 	}, 1500);
 
 	setTimeout(() => {
-		processSpinner.succeed(chalk.green('Unicorn magic processed successfully!'));
+		processSpinner.succeed(styleText('green', 'Unicorn magic processed successfully!'));
 
 		// Deploy unicorn powers
 		const deploySpinner = ora({
@@ -63,32 +64,35 @@ setTimeout(() => {
 		}).start();
 
 		setTimeout(() => {
-			console.error(chalk.hex('#FF1493')('💫 Spreading joy and sparkles'));
+			// mapped #FF1493 -> magentaBright
+			console.error(styleText('magentaBright', '💫 Spreading joy and sparkles'));
 		}, 400);
 
 		setTimeout(() => {
-			console.error(chalk.hex('#9370DB')('🎨 Painting rainbows across the sky'));
+			// mapped #9370DB -> magenta
+			console.error(styleText('magenta', '🎨 Painting rainbows across the sky'));
 		}, 800);
 
 		setTimeout(() => {
-			console.error(chalk.hex('#FFD700')('⭐ Granting wishes to believers'));
+			// mapped #FFD700 -> yellowBright
+			console.error(styleText('yellowBright', '⭐ Granting wishes to believers'));
 		}, 1200);
 
 		setTimeout(() => {
-			deploySpinner.succeed(chalk.bold.green('🦄 Unicorn powers deployed! The world is more magical now! ✨'));
+			deploySpinner.succeed(styleText(['bold', 'green'], '🦄 Unicorn powers deployed! The world is more magical now! ✨'));
 
 			// Summary (using console.log is fine here since spinner is stopped)
-			console.log(chalk.dim('\n' + '─'.repeat(60)));
-			console.log(chalk.bold.cyan('\n📊 Mission Summary:'));
-			console.log(chalk.white('  • Unicorns collected: ') + chalk.bold('3'));
-			console.log(chalk.white('  • Magic spells cast: ') + chalk.bold('6'));
-			console.log(chalk.white('  • Rainbows created: ') + chalk.bold('∞'));
-			console.log(chalk.white('  • World happiness: ') + chalk.bold.green('+1000%'));
-			console.log(chalk.dim('\n' + '─'.repeat(60)));
+			console.log(styleText('dim', '\n' + '─'.repeat(60)));
+			console.log(styleText(['bold', 'cyan'], '\n📊 Mission Summary:'));
+			console.log(styleText('white', '  • Unicorns collected: ') + styleText('bold', '3'));
+			console.log(styleText('white', '  • Magic spells cast: ') + styleText('bold', '6'));
+			console.log(styleText('white', '  • Rainbows created: ') + styleText('bold', '∞'));
+			console.log(styleText('white', '  • World happiness: ') + styleText(['bold', 'green'], '+1000%'));
+			console.log(styleText('dim', '\n' + '─'.repeat(60)));
 
-			console.log(chalk.bold.magenta('\n✨ Notice how all console.error/warn appeared cleanly above the spinner!'));
-			console.log(chalk.dim('The spinner automatically clears, shows your message, then re-renders below.'));
-			console.log(chalk.dim('Both console.log() and console.error/warn() work seamlessly while spinning! 🎉\n'));
+			console.log(styleText(['bold', 'magenta'], '\n✨ Notice how all console.error/warn appeared cleanly above the spinner!'));
+			console.log(styleText('dim', 'The spinner automatically clears, shows your message, then re-renders below.'));
+			console.log(styleText('dim', 'Both console.log() and console.error/warn() work seamlessly while spinning! 🎉\n'));
 		}, 1600);
 	}, 2000);
 }, 3000);

--- a/example-overflow.js
+++ b/example-overflow.js
@@ -1,17 +1,17 @@
 #!/usr/bin/env node
 import process from 'node:process';
-import chalk from 'chalk';
+import { styleText } from 'node:util';
 import ora from './index.js';
 
-console.log(chalk.bold.cyan('\n📏 Terminal Height Overflow Test - Fixed Version 📏'));
-console.log(chalk.gray('This demo shows the fix for issue #121 - multiline content exceeding terminal height.\n'));
+console.log(styleText(['bold', 'cyan'], '\n📏 Terminal Height Overflow Test - Fixed Version 📏'));
+console.log(styleText('dim', 'This demo shows the fix for issue #121 - multiline content exceeding terminal height.\n'));
 
 // Get terminal dimensions
 const rows = process.stderr.rows ?? 30;
 const cols = process.stderr.columns ?? 80;
 
-console.log(chalk.yellow(`Your terminal: ${rows} rows × ${cols} columns`));
-console.log(chalk.green(`Creating spinner with ${rows + 10} lines (exceeds by 10 lines)\n`));
+console.log(styleText('yellow', `Your terminal: ${rows} rows × ${cols} columns`));
+console.log(styleText('green', `Creating spinner with ${rows + 10} lines (exceeds by 10 lines)\n`));
 
 // Create content that exceeds terminal height
 const lines = [];
@@ -37,14 +37,14 @@ const interval = setInterval(() => {
 		clearInterval(interval);
 		spinner.succeed('Done! Content that exceeded terminal height has been properly cleared.');
 
-		console.log('\n' + chalk.bold.green('✅ The Fix:'));
-		console.log(chalk.white('When content exceeds terminal height, ora now:'));
-		console.log(chalk.gray('  1. Detects the overflow (lines > terminal rows)'));
-		console.log(chalk.gray('  2. Truncates content to fit terminal with message'));
-		console.log(chalk.gray('  3. Prevents garbage lines from being written'));
+		console.log('\n' + styleText(['bold', 'green'], '✅ The Fix:'));
+		console.log(styleText('white', 'When content exceeds terminal height, ora now:'));
+		console.log(styleText('dim', '  1. Detects the overflow (lines > terminal rows)'));
+		console.log(styleText('dim', '  2. Truncates content to fit terminal with message'));
+		console.log(styleText('dim', '  3. Prevents garbage lines from being written'));
 
-		console.log('\n' + chalk.bold.yellow('🔍 Try scrolling up now!'));
-		console.log(chalk.gray('You should NOT see leftover spinner frames above.'));
-		console.log(chalk.gray('Content was truncated to prevent overflow.\n'));
+		console.log('\n' + styleText(['bold', 'yellow'], '🔍 Try scrolling up now!'));
+		console.log(styleText('dim', 'You should NOT see leftover spinner frames above.'));
+		console.log(styleText('dim', 'Content was truncated to prevent overflow.\n'));
 	}
 }, 1000);

--- a/example.js
+++ b/example.js
@@ -1,5 +1,5 @@
 import process from 'node:process';
-import chalk from 'chalk';
+import { styleText } from 'node:util';
 import logSymbols from 'log-symbols';
 import ora from './index.js';
 
@@ -31,7 +31,7 @@ setTimeout(() => {
 
 setTimeout(() => {
 	spinner.color = 'yellow';
-	spinner.text = `Loading ${chalk.red('rainbows')}`;
+	spinner.text = `Loading ${styleText('red', 'rainbows')}`;
 }, 4000);
 
 setTimeout(() => {
@@ -47,20 +47,20 @@ setTimeout(() => {
 }, 6000);
 
 setTimeout(() => {
-	spinner.prefixText = chalk.dim('[info]');
+	spinner.prefixText = styleText('dim', '[info]');
 	spinner.spinner = 'dots';
 	spinner.text = 'Loading with prefix text';
 }, 8000);
 
 setTimeout(() => {
 	spinner.prefixText = '';
-	spinner.suffixText = chalk.dim('[info]');
+	spinner.suffixText = styleText('dim', '[info]');
 	spinner.text = 'Loading with suffix text';
 }, 10_000);
 
 setTimeout(() => {
-	spinner.prefixText = chalk.dim('[info]');
-	spinner.suffixText = chalk.dim('[info]');
+	spinner.prefixText = styleText('dim', '[info]');
+	spinner.suffixText = styleText('dim', '[info]');
 	spinner.text = 'Loading with prefix and suffix text';
 }, 12_000);
 

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 import process from 'node:process';
 import {stripVTControlCharacters} from 'node:util';
-import chalk from 'chalk';
+import { styleText } from 'node:util';
 import cliCursor from 'cli-cursor';
 import cliSpinners from 'cli-spinners';
 import logSymbols from 'log-symbols';
@@ -320,7 +320,7 @@ class Ora {
 		let frame = frames[this.#frameIndex];
 
 		if (this.color) {
-			frame = chalk[this.color](frame);
+			frame = styleText([this.color], frame);
 		}
 
 		const fullPrefixText = this.#getFullPrefixText(this.#options.prefixText, ' ');

--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
 		"idle"
 	],
 	"dependencies": {
-		"chalk": "^5.6.2",
 		"cli-cursor": "^5.0.0",
 		"cli-spinners": "^3.2.0",
 		"is-interactive": "^2.0.0",
@@ -54,7 +53,6 @@
 	},
 	"devDependencies": {
 		"@types/node": "^24.5.0",
-		"ava": "^6.4.1",
 		"get-stream": "^9.0.1",
 		"transform-tty": "^1.0.11",
 		"tsd": "^0.33.0",

--- a/readme.md
+++ b/readme.md
@@ -299,13 +299,13 @@ All [provided spinners](https://github.com/sindresorhus/cli-spinners/blob/main/s
 
 ### How do I change the color of the text?
 
-Use [`chalk`](https://github.com/chalk/chalk) or [`yoctocolors`](https://github.com/sindresorhus/yoctocolors):
+Use Node.js' [`styleText`](https://nodejs.org/api/util.html#utilstyletextformat-text-options):
 
 ```js
 import ora from 'ora';
-import chalk from 'chalk';
+import { styleText } from 'node:utils';
 
-const spinner = ora(`Loading ${chalk.red('unicorns')}`).start();
+const spinner = ora(`Loading ${styleText('red', 'unicorns')}`).start();
 ```
 
 ### Why does the spinner freeze?


### PR DESCRIPTION
Hi!

Node 20 and above supports styleText, which is essentially a 1:1 replacement for chalk and similar libraries. This PR replaces chalk with this node-native solution.

I've also removed `ava` from dependency list, because it appears to be unused.

If the PR is not wanted, I apologize and feel free to close!