### PR TITLE
Adopt latest stdin-discarder version

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
 		"is-interactive": "^2.0.0",
 		"is-unicode-supported": "^2.1.0",
 		"log-symbols": "^7.0.1",
-		"stdin-discarder": "^0.2.2",
+		"stdin-discarder": "^0.3.1",
 		"string-width": "^8.1.0"
 	},
 	"devDependencies": {


### PR DESCRIPTION
To fix `ora` process hanging when stdin stays open, https://github.com/sindresorhus/stdin-discarder/commit/f917ce9ab87a91730727cfa206b8409350e26348 was implemented. This solves #248 , but the `stdin-discarder` version that has the fix was never adopted here.

Adopting the fixed version