### PR TITLE
Fix type definitions that contradict the implementation

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -56,9 +56,11 @@ export type Options = {
 	/**
 	The color of the spinner.
 
+	Set to `false` to disable the color.
+
 	@default 'cyan'
 	*/
-	readonly color?: Color | boolean;
+	readonly color?: Color | false;
 
 	/**
 	Set to `false` to stop Ora from hiding the cursor.
@@ -208,19 +210,21 @@ export interface Ora {
 
 	No prefix text will be displayed if set to an empty string.
 	*/
-	prefixText: string;
+	prefixText: string | PrefixTextGenerator;
 
 	/**
 	Change the text or function that returns text after the spinner text.
 
 	No suffix text will be displayed if set to an empty string.
 	*/
-	suffixText: string;
+	suffixText: string | SuffixTextGenerator;
 
 	/**
 	Change the spinner color.
+
+	Set to `false` to disable the color.
 	*/
-	color: Color | boolean;
+	color: Color | false;
 
 	/**
 	Change the spinner indent.

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -1,5 +1,5 @@
 import {PassThrough as PassThroughStream} from 'node:stream';
-import {expectType} from 'tsd';
+import {expectError, expectType} from 'tsd';
 import type cliSpinners from 'cli-spinners';
 import ora, {oraPromise, spinners} from './index.js';
 
@@ -14,6 +14,7 @@ ora({spinner: {frames: ['-', '+', '-']}});
 ora({spinner: {interval: 80, frames: ['-', '+', '-']}});
 ora({color: 'cyan'});
 ora({color: false});
+expectError(ora({color: true}));
 ora({hideCursor: true});
 ora({indent: 1});
 ora({interval: 80});
@@ -24,7 +25,12 @@ ora({discardStdin: true});
 
 spinner.color = 'yellow';
 spinner.color = false;
+expectError(spinner.color = true);
 spinner.text = 'Loading rainbows';
+spinner.prefixText = 'Loading';
+spinner.prefixText = () => 'Loading dynamically';
+spinner.suffixText = '[loading]';
+spinner.suffixText = () => '[loading dynamically]';
 expectType<boolean>(spinner.isSpinning);
 spinner.spinner = 'dots';
 spinner.indent = 5;


### PR DESCRIPTION
While using the types, I hit two cases where the type definitions disagree with what `index.js` actually does.

### `color` allows `true`, but the setter rejects it

`color` is typed as `Color | boolean` on both `Options` and the `Ora` interface, so `color: true` type-checks. At runtime the setter throws for anything that is not a valid color or `false`:

```js
set color(value) {
	if (value !== undefined && value !== false && !validColors.has(value)) {
		throw new Error('The `color` option must be a valid color or `false` to disable');
	}

	this.#color = value;
}
```

So this compiles but throws:

```js
ora({color: true}); // Error: The `color` option must be a valid color or `false` to disable
```

`false` is meaningful (it disables the color), but `true` is not a valid value. This narrows the type to `Color | false` in both places.

### `prefixText`/`suffixText` on the `Ora` interface drop the function form

On the `Ora` interface, `prefixText` and `suffixText` are typed as `string`, but the implementation resolves a function by calling it:

```js
#formatAffix(value, separator, placeBefore = false) {
	const resolved = typeof value === 'function' ? value() : value;
	...
}
```

The JSDoc on both members already says "text or function that returns text", the `PrefixTextGenerator`/`SuffixTextGenerator` types are already exported, and `Options` and `PersistOptions` already use `string | PrefixTextGenerator` / `string | SuffixTextGenerator`. Only the `Ora` interface members were left as plain `string`, so assigning a function to `spinner.prefixText` is a type error even though it works at runtime. This widens them to match.

### Tests

Added `tsd` assertions for the rejected `color: true` and for the function forms of `prefixText`/`suffixText`.