### PR TITLE
Remove unused ava devDependency and fix readme typo

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,6 @@
 	},
 	"devDependencies": {
 		"@types/node": "^24.5.0",
-		"ava": "^6.4.1",
 		"get-stream": "^9.0.1",
 		"tsd": "^0.33.0",
 		"xo": "^1.2.2"

--- a/readme.md
+++ b/readme.md
@@ -230,7 +230,7 @@ Symbol to replace the spinner with.
 ###### text
 
 Type: `string`\
-Default: Current `'text'`
+Default: Current `text`
 
 Text to be persisted after the symbol.
 


### PR DESCRIPTION
- Removed `ava` from `devDependencies` -> the test suite uses Node.js built-in `node:test`, not ava (drops 115 packages
  from the dev dependency tree)
 - Fixed `stopAndPersist` `text` option default in readme -> was `Current 'text'` (looks like a string literal) now
  `Current text` (property reference) matching `prefixText`/`suffixText` style

Test plan
  - [x] `NODE_ENV=test node --test test.js` passes
  - [x] `npx tsd` passes
  - [x] `npm install` confirms ava removal drops 115 packages

Doesnt close any specific issue